### PR TITLE
Fail fast when calling system.file() 

### DIFF
--- a/R/CohortConstruction.R
+++ b/R/CohortConstruction.R
@@ -24,8 +24,8 @@ getCohortsJsonAndSqlFromPackage <- function(packageName = packageName,
     errorMessage <- checkmate::makeAssertCollection()
   }
   checkmate::assertCharacter(x = packageName, min.len = 1, max.len = 1, add = errorMessage)
-  pathToCsv <- system.file(cohortToCreateFile, package = packageName)
-  checkmate::assertFileExists(x = system.file(cohortToCreateFile, package = packageName), 
+  pathToCsv <- system.file(cohortToCreateFile, package = packageName, mustWork = TRUE)
+  checkmate::assertFileExists(x = system.file(cohortToCreateFile, package = packageName, mustWork = TRUE), 
                               access = "r", 
                               extension = "csv", 
                               add = errorMessage)
@@ -49,14 +49,14 @@ getCohortsJsonAndSqlFromPackage <- function(packageName = packageName,
     dplyr::rename(cohortFullName = .data$atlasName, cohortName = .data$name)
   
   getSql <- function(name) {
-    pathToSql <- system.file("sql", "sql_server", paste0(name, ".sql"), package = packageName)
+    pathToSql <- system.file("sql", "sql_server", paste0(name, ".sql"), package = packageName, mustWork = TRUE)
     checkmate::assertFile(x = pathToSql, access = "r", extension = ".sql", add = errorMessage)
     sql <- readChar(pathToSql, file.info(pathToSql)$size)
     return(sql)
   }
   cohorts$sql <- sapply(cohorts$cohortName, getSql)
   getJson <- function(name) {
-    pathToJson <- system.file("cohorts", paste0(name, ".json"), package = packageName)
+    pathToJson <- system.file("cohorts", paste0(name, ".json"), package = packageName, mustWork = TRUE)
     checkmate::assertFile(x = pathToJson, access = "r", extension = ".sql", add = errorMessage)
     json <- readChar(pathToJson, file.info(pathToJson)$size)
     return(json)
@@ -710,7 +710,7 @@ instantiateCohortSet <- function(connectionDetails = NULL,
 
 createTempInclusionStatsTables <- function(connection, oracleTempSchema, cohorts) {
   ParallelLogger::logInfo("Creating temporary inclusion statistics tables")
-  pathToSql <- system.file( "inclusionStatsTables.sql", package = "ROhdsiWebApi")
+  pathToSql <- system.file( "inclusionStatsTables.sql", package = "ROhdsiWebApi", mustWork = TRUE)
   sql <- SqlRender::readSql(pathToSql)
   sql <- SqlRender::translate(sql, targetDialect = connection@dbms, oracleTempSchema = oracleTempSchema)
   DatabaseConnector::executeSql(connection, sql)

--- a/R/CohortLevelDiagnostics.R
+++ b/R/CohortLevelDiagnostics.R
@@ -165,7 +165,7 @@ breakDownIndexEvents <- function(connectionDetails = NULL,
   instantiateConceptSets(connection, cdmDatabaseSchema, oracleTempSchema, cohortSql)
   
   ParallelLogger::logInfo("Computing counts")
-  domains <- readr::read_csv(system.file("csv", "domains.csv", package = "CohortDiagnostics"),
+  domains <- readr::read_csv(system.file("csv", "domains.csv", package = "CohortDiagnostics", mustWork = TRUE),
                              col_types = readr::cols())
   getCounts <- function(row) {
     domain <- domains[domains$domain == row$domain, ]

--- a/R/Shiny.R
+++ b/R/Shiny.R
@@ -33,7 +33,7 @@ launchDiagnosticsExplorer <- function(dataFolder, launch.browser = FALSE) {
   ensure_installed("DT")
   ensure_installed("VennDiagram")
   ensure_installed("htmltools")
-  appDir <- system.file("shiny", "DiagnosticsExplorer", package = "CohortDiagnostics")
+  appDir <- system.file("shiny", "DiagnosticsExplorer", package = "CohortDiagnostics", mustWork = TRUE)
   shinySettings <- list(dataFolder = dataFolder)
   .GlobalEnv$shinySettings <- shinySettings
   on.exit(rm(shinySettings, envir = .GlobalEnv))
@@ -145,7 +145,7 @@ launchCohortExplorer <- function(connectionDetails,
                                    sampleSize = sampleSize,
                                    subjectIds = subjectIds)
   on.exit(rm(shinySettings, envir = .GlobalEnv))
-  appDir <- system.file("shiny", "CohortExplorer", package = "CohortDiagnostics")
+  appDir <- system.file("shiny", "CohortExplorer", package = "CohortDiagnostics", mustWork = TRUE)
   shiny::runApp(appDir)
 }
 

--- a/exampleComparativeCohortStudy/R/CohortMethod.R
+++ b/exampleComparativeCohortStudy/R/CohortMethod.R
@@ -53,7 +53,8 @@ runCohortMethod <- function(connectionDetails,
   }
   cmAnalysisListFile <- system.file("settings",
                                     "cmAnalysisList.json",
-                                    package = "exampleStudy")
+                                    package = "exampleStudy",
+                                    mustWork = TRUE)
   cmAnalysisList <- CohortMethod::loadCmAnalysisList(cmAnalysisListFile)
   tcosList <- createTcos(outputFolder = outputFolder)
   outcomesOfInterest <- getOutcomesOfInterest()
@@ -118,7 +119,8 @@ computeCovariateBalance <- function(row, cmOutputFolder, balanceFolder) {
 addAnalysisDescription <- function(data, IdColumnName = "analysisId", nameColumnName = "analysisDescription") {
   cmAnalysisListFile <- system.file("settings",
                                     "cmAnalysisList.json",
-                                    package = "exampleStudy")
+                                    package = "exampleStudy",
+                                    mustWork = TRUE)
   cmAnalysisList <- CohortMethod::loadCmAnalysisList(cmAnalysisListFile)
   idToName <- lapply(cmAnalysisList, function(x) data.frame(analysisId = x$analysisId, description = as.character(x$description)))
   idToName <- do.call("rbind", idToName)
@@ -134,7 +136,7 @@ addAnalysisDescription <- function(data, IdColumnName = "analysisId", nameColumn
 }
 
 createTcos <- function(outputFolder) {
-  pathToCsv <- system.file("settings", "TcosOfInterest.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "TcosOfInterest.csv", package = "exampleStudy", mustWork = TRUE)
   tcosOfInterest <- read.csv(pathToCsv, stringsAsFactors = FALSE)
   allControls <- getAllControls(outputFolder)
   tcs <- unique(rbind(tcosOfInterest[, c("targetId", "comparatorId")],
@@ -169,7 +171,7 @@ createTcos <- function(outputFolder) {
 }
 
 getOutcomesOfInterest <- function() {
-  pathToCsv <- system.file("settings", "TcosOfInterest.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "TcosOfInterest.csv", package = "exampleStudy", mustWork = TRUE)
   tcosOfInterest <- read.csv(pathToCsv, stringsAsFactors = FALSE) 
   outcomeIds <- as.character(tcosOfInterest$outcomeIds)
   outcomeIds <- do.call("c", (strsplit(outcomeIds, split = ";")))
@@ -184,7 +186,7 @@ getAllControls <- function(outputFolder) {
     allControls <- read.csv(allControlsFile)
   } else {
     # Include only negative controls
-    pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy")
+    pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy", mustWork = TRUE)
     allControls <- read.csv(pathToCsv)
     allControls$oldOutcomeId <- allControls$outcomeId
     allControls$targetEffectSize <- rep(1, nrow(allControls))

--- a/exampleComparativeCohortStudy/R/CreateAllCohorts.R
+++ b/exampleComparativeCohortStudy/R/CreateAllCohorts.R
@@ -56,7 +56,7 @@ createCohorts <- function(connectionDetails,
                  oracleTempSchema = oracleTempSchema,
                  outputFolder = outputFolder)
   
-  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy", mustWork = TRUE)
   negativeControls <- read.csv(pathToCsv)
   
   ParallelLogger::logInfo("Creating negative control outcome cohorts")
@@ -90,9 +90,9 @@ createCohorts <- function(connectionDetails,
 }
 
 addCohortNames <- function(data, IdColumnName = "cohortDefinitionId", nameColumnName = "cohortName") {
-  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "exampleStudy", mustWork = TRUE)
   cohortsToCreate <- read.csv(pathToCsv)
-  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy", mustWork = TRUE)
   negativeControls <- read.csv(pathToCsv)
   
   idToName <- data.frame(cohortId = c(cohortsToCreate$cohortId,

--- a/exampleComparativeCohortStudy/R/CreateCohorts.R
+++ b/exampleComparativeCohortStudy/R/CreateCohorts.R
@@ -33,7 +33,7 @@
   
   
   # Insert rule names in cohort_inclusion table:
-  pathToCsv <- system.file("cohorts", "InclusionRules.csv", package = "exampleStudy")
+  pathToCsv <- system.file("cohorts", "InclusionRules.csv", package = "exampleStudy", mustWork = TRUE)
   inclusionRules <- read.csv(pathToCsv)  
   inclusionRules <- data.frame(cohort_definition_id = inclusionRules$cohortId,
                                rule_sequence = inclusionRules$ruleSequence,
@@ -48,7 +48,7 @@
   
   
   # Instantiate cohorts:
-  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "exampleStudy", mustWork = TRUE)
   cohortsToCreate <- read.csv(pathToCsv)
   for (i in 1:nrow(cohortsToCreate)) {
     writeLines(paste("Creating cohort:", cohortsToCreate$name[i]))

--- a/exampleComparativeCohortStudy/R/Export.R
+++ b/exampleComparativeCohortStudy/R/Export.R
@@ -87,7 +87,8 @@ exportAnalyses <- function(outputFolder, exportFolder) {
   
   cmAnalysisListFile <- system.file("settings",
                                     "cmAnalysisList.json",
-                                    package = "exampleStudy")
+                                    package = "exampleStudy",
+                                    mustWork = TRUE)
   cmAnalysisList <- CohortMethod::loadCmAnalysisList(cmAnalysisListFile)
   cmAnalysisToRow <- function(cmAnalysis) {
     ParallelLogger::saveSettingsToJson(cmAnalysis, tempFileName)
@@ -125,14 +126,14 @@ exportAnalyses <- function(outputFolder, exportFolder) {
 exportExposures <- function(outputFolder, exportFolder) {
   ParallelLogger::logInfo("Exporting exposures")
   ParallelLogger::logInfo("- exposure_of_interest table")
-  pathToCsv <- system.file("settings", "TcosOfInterest.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "TcosOfInterest.csv", package = "exampleStudy", mustWork = TRUE)
   tcosOfInterest <- read.csv(pathToCsv, stringsAsFactors = FALSE)
-  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "exampleStudy", mustWork = TRUE)
   cohortsToCreate <- read.csv(pathToCsv)
   createExposureRow <- function(exposureId) {
     atlasName <- as.character(cohortsToCreate$atlasName[cohortsToCreate$cohortId == exposureId])
     name <- as.character(cohortsToCreate$name[cohortsToCreate$cohortId == exposureId])
-    cohortFileName <- system.file("cohorts", paste0(name, ".json"), package = "exampleStudy")
+    cohortFileName <- system.file("cohorts", paste0(name, ".json"), package = "exampleStudy", mustWork = TRUE)
     definition <- readChar(cohortFileName, file.info(cohortFileName)$size)
     return(data.frame(exposureId = exposureId,
                       exposureName = atlasName,
@@ -149,12 +150,12 @@ exportExposures <- function(outputFolder, exportFolder) {
 exportOutcomes <- function(outputFolder, exportFolder) {
   ParallelLogger::logInfo("Exporting outcomes")
   ParallelLogger::logInfo("- outcome_of_interest table")
-  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "exampleStudy", mustWork = TRUE)
   cohortsToCreate <- read.csv(pathToCsv)
   createOutcomeRow <- function(outcomeId) {
     atlasName <- as.character(cohortsToCreate$atlasName[cohortsToCreate$cohortId == outcomeId])
     name <- as.character(cohortsToCreate$name[cohortsToCreate$cohortId == outcomeId])
-    cohortFileName <- system.file("cohorts", paste0(name, ".json"), package = "exampleStudy")
+    cohortFileName <- system.file("cohorts", paste0(name, ".json"), package = "exampleStudy", mustWork = TRUE)
     definition <- readChar(cohortFileName, file.info(cohortFileName)$size)
     return(data.frame(outcomeId = outcomeId,
                       outcomeName = atlasName,
@@ -169,7 +170,7 @@ exportOutcomes <- function(outputFolder, exportFolder) {
   
   
   ParallelLogger::logInfo("- negative_control_outcome table")
-  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy", mustWork = TRUE)
   negativeControls <- read.csv(pathToCsv)
   negativeControls <- negativeControls[tolower(negativeControls$type) == "outcome", ]
   negativeControls <- negativeControls[, c("outcomeId", "outcomeName")]
@@ -181,7 +182,7 @@ exportOutcomes <- function(outputFolder, exportFolder) {
   synthesisSummaryFile <- file.path(outputFolder, "SynthesisSummary.csv")
   if (file.exists(synthesisSummaryFile)) {
     positiveControls <- read.csv(synthesisSummaryFile, stringsAsFactors = FALSE)
-    pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy")
+    pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy", mustWork = TRUE)
     negativeControls <- read.csv(pathToCsv)
     positiveControls <- merge(positiveControls,
                               negativeControls[, c("outcomeId", "outcomeName")])

--- a/exampleComparativeCohortStudy/R/ShinyApps.R
+++ b/exampleComparativeCohortStudy/R/ShinyApps.R
@@ -85,7 +85,7 @@ prepareForEvidenceExplorer <- function(resultsZipFile, dataFolder) {
 #' @export
 launchEvidenceExplorer <- function(dataFolder, blind = TRUE, launch.browser = TRUE) {
   ensure_installed("DT")
-  appDir <- system.file("shiny", "EvidenceExplorer", package = "exampleStudy")
+  appDir <- system.file("shiny", "EvidenceExplorer", package = "exampleStudy", mustWork = TRUE)
   .GlobalEnv$shinySettings <- list(dataFolder = dataFolder, blind = blind)
   on.exit(rm(shinySettings, envir=.GlobalEnv))
   shiny::runApp(appDir) 

--- a/exampleComparativeCohortStudy/R/SynthesizePositiveControls.R
+++ b/exampleComparativeCohortStudy/R/SynthesizePositiveControls.R
@@ -55,12 +55,12 @@ synthesizePositiveControls <- function(connectionDetails,
   
   synthesisSummaryFile <- file.path(outputFolder, "SynthesisSummary.csv")
   if (!file.exists(synthesisSummaryFile)) {
-    pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy")
+    pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy", mustWork = TRUE)
     negativeControls <- read.csv(pathToCsv)
     exposureOutcomePairs <- data.frame(exposureId = negativeControls$targetId,
                                        outcomeId = negativeControls$outcomeId)
     exposureOutcomePairs <- unique(exposureOutcomePairs)
-    pathToJson <- system.file("settings", "positiveControlSynthArgs.json", package = "exampleStudy")
+    pathToJson <- system.file("settings", "positiveControlSynthArgs.json", package = "exampleStudy", mustWork = TRUE)
     args <- ParallelLogger::loadSettingsFromJson(pathToJson)
     args$control$threads <- min(c(10, maxCores))
     
@@ -103,7 +103,7 @@ synthesizePositiveControls <- function(connectionDetails,
     result <- read.csv(synthesisSummaryFile)
   }
   ParallelLogger::logTrace("Merging positive with negative controls ")
-  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy", mustWork = TRUE)
   negativeControls <- read.csv(pathToCsv)
   
   synthesisSummary <- read.csv(synthesisSummaryFile)
@@ -114,7 +114,7 @@ synthesizePositiveControls <- function(connectionDetails,
   synthesisSummary$oldOutcomeId <- synthesisSummary$outcomeId
   synthesisSummary$outcomeId <- synthesisSummary$newOutcomeId
   
-  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy")
+  pathToCsv <- system.file("settings", "NegativeControls.csv", package = "exampleStudy", mustWork = TRUE)
   negativeControls <- read.csv(pathToCsv)
   negativeControls$targetEffectSize <- 1
   negativeControls$trueEffectSize <- 1

--- a/examplePackage/R/CreateCohorts.R
+++ b/examplePackage/R/CreateCohorts.R
@@ -33,7 +33,7 @@
   
   
   # Insert rule names in cohort_inclusion table:
-  pathToCsv <- system.file("cohorts", "InclusionRules.csv", package = "examplePackage")
+  pathToCsv <- system.file("cohorts", "InclusionRules.csv", package = "examplePackage", mustWork = TRUE)
   inclusionRules <- read.csv(pathToCsv)  
   inclusionRules <- data.frame(cohort_definition_id = inclusionRules$cohortId,
                                rule_sequence = inclusionRules$ruleSequence,
@@ -48,7 +48,7 @@
   
   
   # Instantiate cohorts:
-  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "examplePackage")
+  pathToCsv <- system.file("settings", "CohortsToCreate.csv", package = "examplePackage", mustWork = TRUE)
   cohortsToCreate <- read.csv(pathToCsv)
   for (i in 1:nrow(cohortsToCreate)) {
     writeLines(paste("Creating cohort:", cohortsToCreate$name[i]))


### PR DESCRIPTION
When system.file() does not find a file it will by default return an empty string which will almost certainly cause a error further along in execution. This pull request adds the mustWork = TRUE argument to all calls to system.file which will improve the error handling by immediately throwing an informative error when files are not found.