### PR TITLE
Multiselect for most, overview phenotypeDescription,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ errorReportR.txt
 .DS_Store
 *.history
 .RDataTmp
+*.log
+*.log
+*.log

--- a/debug.log
+++ b/debug.log
@@ -1,1 +1,3 @@
 [1011/161110.263:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1012/202253.267:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)
+[1012/231343.600:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/inst/shiny/DiagnosticsExplorer/R/Plots.R
+++ b/inst/shiny/DiagnosticsExplorer/R/Plots.R
@@ -49,13 +49,13 @@ plotTimeDistribution <- function(data,
   
   plotData$tooltip <- c(paste0(plotData$cohortName,
                               "\nDatabase = ", plotData$Database, 
-                              "\nMin = ",  plotData$Min,
-                              "\nMax = ",  plotData$Max,
-                              "\nP25 = ",  plotData$P25,
-                              "\nMedian = ",  plotData$Median,
-                              "\nP75 = ", plotData$P75,
+                              "\nMin = ", scales::comma(plotData$Min),
+                              "\nMax = ", scales::comma(plotData$Max),
+                              "\nP25 = ", scales::comma(plotData$P25),
+                              "\nMedian = ", scales::comma(plotData$Median),
+                              "\nP75 = ", scales::comma(plotData$P75),
                               "\nTime Measure = ",  plotData$TimeMeasure,
-                              "\nAverage = ",  plotData$Average))
+                              "\nAverage = ",  scales::comma(x = plotData$Average, accuracy = 0.01)))
   
   plot <- ggplot2::ggplot(data = plotData) +
     ggplot2::aes(x = .data$Database,
@@ -85,7 +85,7 @@ plotTimeDistribution <- function(data,
                             ggiraph::opts_sizing(width = .7),
                             ggiraph::opts_zoom(max = 5)),
                           width_svg = 12,
-                          height_svg = 0.7 + 0.5 * length(databaseIds))
+                          height_svg = 1.5 + 2*length(unique(databaseIds)))
   return(plot)
 }  
 # how to render using pure plot ly. Plotly does not prefer precomputed data.
@@ -280,8 +280,8 @@ plotIncidenceRate <- function(data,
       plot <- plot + facet_nested(databaseId + shortName ~., scales = scales) 
     }
     spacing <- rep(c(1, rep(0.5, length(unique(plotData$shortName)) - 1)), length(unique(plotData$databaseId)))[-1]
-    plot <- plot + ggplot2::theme(panel.spacing.y = ggplot2::unit(spacing, "lines"),
-                                  strip.background = ggplot2::element_blank())
+    # plot <- plot + ggplot2::theme(panel.spacing.y = ggplot2::unit(spacing, "lines"),
+    #                               strip.background = ggplot2::element_blank())
   } else {
     if (stratifyByAgeGroup) {
       plot <- plot + ggplot2::facet_grid(~ageGroup) 

--- a/inst/shiny/DiagnosticsExplorer/global.R
+++ b/inst/shiny/DiagnosticsExplorer/global.R
@@ -52,7 +52,7 @@ if (!exists("shinySettings")) {
     dataFolder <- defaultLocalDataFolder
   }
   cohortBaseUrl <- defaultCohortBaseUrl
-  conceptBaseUrl <- defaultCohortBaseUrl
+  conceptBaseUrl <- defaultConceptBaseUrl
 } else {
   writeLines("Using settings provided by user")
   databaseMode <- !is.null(shinySettings$connectionDetails)
@@ -161,6 +161,11 @@ if (exists("cohort")) {
       cohort$cohortId - cohort$phenotypeId))
 }
 
+if (exists("database")) {
+  database <- get("database") %>% 
+    dplyr::filter(!database == 'CPRD')
+}
+
 if (exists("temporalTimeRef")) {
   temporalCovariateChoices <- get("temporalTimeRef") %>%
     dplyr::mutate(choices = paste0("Start ", .data$startDay, " to end ", .data$endDay)) %>%
@@ -174,4 +179,24 @@ if (exists("covariateRef")) {
                                     col_types = readr::cols(),
                                     guess_max = min(1e7))
   prettyAnalysisIds <- specifications$analysisId
+}
+
+if (exists("phenotypeDescription")) {
+  phenotypeDescription <- phenotypeDescription %>% 
+    dplyr::mutate(overview = (stringr::str_match(.data$clinicalDescription, 
+                                                 "Overview:(.*?)Presentation:"))[,2] %>%
+                    stringr::str_squish() %>% 
+                    stringr::str_trim()) %>% 
+    dplyr::mutate(clinicalDescription = stringr::str_replace_all(string = .data$clinicalDescription, 
+                                                                 pattern = "Overview:", 
+                                                                 replacement = "<strong>Overview:</strong>")) %>% 
+    dplyr::mutate(clinicalDescription = stringr::str_replace_all(string = .data$clinicalDescription, 
+                                                                 pattern = "Assessment:", 
+                                                                 replacement = "<br/> <strong>Assessment:</strong>")) %>% 
+    dplyr::mutate(clinicalDescription = stringr::str_replace_all(string = .data$clinicalDescription, 
+                                                                 pattern = "Presentation:", 
+                                                                 replacement = "<br/> <strong>Presentation: </strong>")) %>% 
+    dplyr::mutate(clinicalDescription = stringr::str_replace_all(string = .data$clinicalDescription,
+                                                                 pattern = "Plan:",
+                                                                 replacement = "<br/> <strong>Plan: </strong>"))
 }

--- a/inst/shiny/DiagnosticsExplorer/ui.R
+++ b/inst/shiny/DiagnosticsExplorer/ui.R
@@ -220,16 +220,18 @@ sidebarMenu <-
       )
     },
     shiny::conditionalPanel(
-      condition = "input.tabs!='cohortCounts' & 
-      input.tabs != 'databaseInformation' & 
+      condition = "input.tabs != 'databaseInformation' & 
       input.tabs != 'cohortDescription' &
+      input.tabs != 'cohortCounts' &
       input.tabs != 'phenotypeDescription' & 
       input.tabs != 'cohortOverlap'&
       input.tabs != 'compareCohortCharacterization' &
       input.tabs != 'incidenceRate' &
       input.tabs != 'timeDistribution' &
+      input.tabs != 'indexEventBreakdown' &
       input.tabs != 'cohortCharacterization' &
-      input.tabs != 'temporalCharacterization'",
+      input.tabs != 'temporalCharacterization' &
+      input.tabs != 'visitContext'",
       shinyWidgets::pickerInput(
         inputId = "cohort",
         label = "Cohorts",
@@ -257,18 +259,22 @@ sidebarMenu <-
           actionsBox = TRUE,
           liveSearch = TRUE,
           size = 10,
+          dropupAuto = TRUE,
           liveSearchStyle = "contains",
           liveSearchPlaceholder = "Type here to search",
           virtualScroll = 50)
       )
     ),
     shiny::conditionalPanel(
-      condition = "input.tabs == 'cohortOverlap' |
+      condition = "input.tabs == 'cohortCounts' |
+      input.tabs == 'cohortOverlap' |
       input.tabs == 'compareCohortCharacterization' |
       input.tabs == 'incidenceRate' |
       input.tabs == 'timeDistribution' |
+      input.tabs == 'indexEventBreakdown' |
       input.tabs == 'cohortCharacterization' |
-      input.tabs == 'temporalCharacterization'",
+      input.tabs == 'temporalCharacterization' |
+      input.tabs == 'visitContext'",
       shinyWidgets::pickerInput(
         inputId = "cohorts",
         label = "Cohorts",
@@ -281,6 +287,7 @@ sidebarMenu <-
           liveSearch = TRUE, 
           liveSearchStyle = "contains",
           size = 10,
+          dropupAuto = TRUE,
           liveSearchPlaceholder = "Type here to search",
           virtualScroll = 50)
       )
@@ -354,6 +361,7 @@ bodyTabItems <- shinydashboard::tabItems(
     )
   ),
   shinydashboard::tabItem(tabName = "cohortCounts",
+                          shiny::htmlOutput(outputId = "cohortCountsSelectedCohort"),
                           DT::dataTableOutput("cohortCountsTable"),
                           ),
   shinydashboard::tabItem(
@@ -422,12 +430,14 @@ bodyTabItems <- shinydashboard::tabItems(
                           tags$br(),
                           DT::dataTableOutput("inclusionRuleTable")),
   shinydashboard::tabItem(tabName = "indexEventBreakdown",
+                          shiny::htmlOutput(outputId = "indexEventBreakdownSelectedCohort"),
                           DT::dataTableOutput("breakdownTable")),
   shinydashboard::tabItem(tabName = "visitContext",
+                          shiny::htmlOutput(outputId = "visitContextSelectedCohort"),
                           DT::dataTableOutput("visitContextTable")),
   shinydashboard::tabItem(
     tabName = "cohortCharacterization",
-    htmlOutput(outputId = "characterizationSelectedCohort"),
+    shiny::htmlOutput(outputId = "characterizationSelectedCohort"),
     shiny::radioButtons(
       inputId = "charType",
       label = "",
@@ -435,9 +445,6 @@ bodyTabItems <- shinydashboard::tabItems(
       selected = "Pretty",
       inline = TRUE
     ),
-    div(style = "font-size:15px;font-weight: bold", "Target cohort:"),
-    shiny::textOutput(outputId = "cohortCharacterizationSelectedCohort"),
-    tags$br(),
     DT::dataTableOutput("characterizationTable")
   ),
   shinydashboard::tabItem(


### PR DESCRIPTION
* Visit context multi select cohort support
* phenotype description - added overview section. Changed default phenotype to 5, to allow more space for phenotype description. 
* Uniformly use short name to identify cohorts everywhere. Show full cohort names with cohortId on top

* Spacing bug in incidence plot and time dist plot that prevented rendering large number of incidence plots

* Cohort Description now has phenotypeId and name

* Reuse data extract of time distribution using reactive value (optimization) - speeds up time distribution
* Added formatting to tooltip in time distribution
* Index event breakdown supports multiple cohorts
* Visit context table optimizations and multiselect cohorts