### PR TITLE
Cohort overlap optimization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ CohortDiagnostics 2.1.1
 Changes:
 
 1. Additional fields added to database_id (person_days, persons, records, observation_period_min_date, observation_period_max_date)
+2. Optimized cohort overlap.
 
 Bug fixes:
 1. 

--- a/R/CohortComparisonDiagnostics.R
+++ b/R/CohortComparisonDiagnostics.R
@@ -18,8 +18,9 @@ computeCohortOverlap <- function(connectionDetails = NULL,
                                  connection = NULL,
                                  cohortDatabaseSchema,
                                  cohortTable = "cohort",
-                                 targetCohortId,
-                                 comparatorCohortId) {
+                                 targetCohortIds,
+                                 comparatorCohortIds,
+                                 batchSize = 200) {
   start <- Sys.time()
   
   if (is.null(connection)) {
@@ -27,66 +28,87 @@ computeCohortOverlap <- function(connectionDetails = NULL,
     on.exit(DatabaseConnector::disconnect(connection))
   }
   
-  if (!checkIfCohortInstantiated(
-    connection = connection,
-    cohortDatabaseSchema = cohortDatabaseSchema,
-    cohortTable = cohortTable,
-    cohortId = targetCohortId
-  )) {
-    warning(
-      "- Target cohort with ID ",
-      targetCohortId,
-      " appears to be empty. Was it instantiated? Skipping overlap computation."
-    )
-    delta <- Sys.time() - start
-    ParallelLogger::logInfo(paste(
-      "Computing overlap took",
-      signif(delta, 3),
-      attr(delta, "units")
-    ))
-    return(tidyr::tibble())
-  }
+  ## commenting out checks if cohort is instantiated, as this is not essential.
+  ## if a cohort has 0 records, the overlap query will return NULL
+  # if (!checkIfCohortInstantiated(
+  #   connection = connection,
+  #   cohortDatabaseSchema = cohortDatabaseSchema,
+  #   cohortTable = cohortTable,
+  #   cohortId = targetCohortId
+  # )) {
+  #   warning(
+  #     "- Target cohort with ID ",
+  #     targetCohortId,
+  #     " appears to be empty. Was it instantiated? Skipping overlap computation."
+  #   )
+  #   delta <- Sys.time() - start
+  #   ParallelLogger::logInfo(paste(
+  #     "Computing overlap took",
+  #     signif(delta, 3),
+  #     attr(delta, "units")
+  #   ))
+  #   return(tidyr::tibble())
+  # }
   
-  if (!checkIfCohortInstantiated(
-    connection = connection,
-    cohortDatabaseSchema = cohortDatabaseSchema,
-    cohortTable = cohortTable,
-    cohortId = comparatorCohortId
-  )) {
-    warning(
-      "- Comparator cohort with ID ",
-      comparatorCohortId,
-      " appears to be empty. Was it instantiated? Skipping overlap computation."
-    )
-    delta <- Sys.time() - start
-    ParallelLogger::logInfo(paste(
-      "Computing overlap took",
-      signif(delta, 3),
-      attr(delta, "units")
-    ))
-    return(tidyr::tibble())
-  }
+  # if (!checkIfCohortInstantiated(
+  #   connection = connection,
+  #   cohortDatabaseSchema = cohortDatabaseSchema,
+  #   cohortTable = cohortTable,
+  #   cohortId = comparatorCohortId
+  # )) {
+  #   warning(
+  #     "- Comparator cohort with ID ",
+  #     comparatorCohortId,
+  #     " appears to be empty. Was it instantiated? Skipping overlap computation."
+  #   )
+  #   delta <- Sys.time() - start
+  #   ParallelLogger::logInfo(paste(
+  #     "Computing overlap took",
+  #     signif(delta, 3),
+  #     attr(delta, "units")
+  #   ))
+  #   return(tidyr::tibble())
+  # }
   
-  sql <- SqlRender::loadRenderTranslateSql(
-    "CohortOverlap.sql",
-    packageName = "CohortDiagnostics",
-    dbms = connection@dbms,
-    cohort_database_schema = cohortDatabaseSchema,
-    cohort_table = cohortTable,
-    target_cohort_id = targetCohortId,
-    comparator_cohort_id = comparatorCohortId
-  )
-  overlap <- DatabaseConnector::querySql(
-    connection = connection,
-    sql = sql,
-    snakeCaseToCamelCase = TRUE
-  ) %>%
-    tidyr::tibble()
+  cohortIds <- c(targetCohortIds, comparatorCohortIds) %>% unique() %>% arrange()
+  
+  results <- Andromeda::andromeda()
+  for (start in seq(1, length(cohortIds), by = batchSize)) {
+    end <- min(start + batchSize - 1, length(cohortIds))
+    if (length(cohortIds) > batchSize) {
+      ParallelLogger::logInfo(sprintf(
+        "Batch characterization. Processing cohorts %s through %s",
+        start,
+        end
+      ))
+    }
+    
+    sql <- SqlRender::loadRenderTranslateSql(
+      "CohortOverlap.sql",
+      packageName = "CohortDiagnostics",
+      dbms = connection@dbms,
+      cohort_database_schema = cohortDatabaseSchema,
+      cohort_table = cohortTable,
+      target_cohort_id = targetCohortId,
+      comparator_cohort_id = comparatorCohortId
+    )
+    overlap <- DatabaseConnector::querySql(
+      connection = connection,
+      sql = sql,
+      snakeCaseToCamelCase = TRUE
+    )
+    if ("overlap" %in% names(results)) {
+      Andromeda::appendToTable(results$overlap, overlap)
+    } else {
+      results$overlap <- overlap
+    }
+  }
+  overlapAll <- results$overlap %>% dplyr::collect()
   delta <- Sys.time() - start
   ParallelLogger::logInfo(paste(
     "Computing overlap took",
     signif(delta, 3),
     attr(delta, "units")
   ))
-  return(overlap)
+  return(overlapAll)
 }

--- a/R/Private.R
+++ b/R/Private.R
@@ -42,16 +42,6 @@ createIfNotExist <-
     invisible(errorMessage)
   }
 
-swapColumnContents <-
-  function(df,
-           column1 = "targetId",
-           column2 = "comparatorId") {
-    temp <- df[, column1]
-    df[, column1] <- df[, column2]
-    df[, column2] <- temp
-    return(df)
-  }
-
 enforceMinCellValue <-
   function(data, fieldName, minValues, silent = FALSE) {
     toCensor <-

--- a/R/RunDiagnostics.R
+++ b/R/RunDiagnostics.R
@@ -983,16 +983,7 @@ runCohortDiagnostics <- function(packageName = NULL,
         comparatorCohortId = combis$comparatorCohortId %>% unique()
       )
       if (nrow(data) > 0) {
-        revData <- data
-        revData <-
-          swapColumnContents(revData, "targetCohortId", "comparatorCohortId")
-        revData <-
-          swapColumnContents(revData, "tOnlySubjects", "cOnlySubjects")
-        revData <-
-          swapColumnContents(revData, "tBeforeCSubjects", "cBeforeTSubjects")
-        revData <-
-          swapColumnContents(revData, "tInCSubjects", "cInTSubjects")
-        data <- dplyr::bind_rows(data, revData) %>%
+        data <- data %>%
           dplyr::mutate(databaseId = !!databaseId)
         data <-
           enforceMinCellValue(data, "eitherSubjects", minCellCount)

--- a/R/RunDiagnostics.R
+++ b/R/RunDiagnostics.R
@@ -939,7 +939,7 @@ runCohortDiagnostics <- function(packageName = NULL,
     
     combis <- tidyr::crossing(combis %>% dplyr::rename("targetCohortId" = .data$cohortId),
                               combis %>% dplyr::rename("comparatorCohortId" = .data$cohortId)) %>%
-      dplyr::filter(.data$targetCohortId < .data$comparatorCohortId) %>%
+      dplyr::filter(.data$targetCohortId != .data$comparatorCohortId) %>%
       dplyr::select(.data$targetCohortId, .data$comparatorCohortId) %>%
       dplyr::distinct()
     
@@ -1015,7 +1015,11 @@ runCohortDiagnostics <- function(packageName = NULL,
         data <- data %>%
           dplyr::mutate(dplyr::across(.cols = everything(), ~ tidyr::replace_na(
             data = ., replace = 0
-          )))
+          ))) %>% 
+          dplyr::select(.data$eitherSubjects, .data$bothSubjects, .data$tOnlySubjects,
+                        .data$cOnlySubjects, .data$tBeforeCSubjects, .data$cBeforeTSubjects,
+                        .data$sameDaySubjects, .data$tInCSubjects, .data$cInTSubjects,
+                        .data$targetCohortId, .data$comparatorCohortId, .data$databaseId)
         
         writeToCsv(
           data = data,

--- a/inst/sql/sql_server/CohortOverlap.sql
+++ b/inst/sql/sql_server/CohortOverlap.sql
@@ -1,4 +1,4 @@
-SELECT u.target_cohort_id,
+SELECT DISTINCT u.target_cohort_id,
 	u.comparator_cohort_id,
 	u.num_persons_in_either AS either_subjects,
 	u.num_persons_in_both AS both_subjects,
@@ -49,10 +49,11 @@ FROM (
 		FROM @cohort_database_schema.@cohort_table
 		WHERE cohort_definition_id IN (@comparator_cohort_ids)
 		) c1 ON all_persons.subject_id = c1.subject_id
+	WHERE t1.target_cohort_id != c1.comparator_cohort_id
 	GROUP BY t1.target_cohort_id,
 		c1.comparator_cohort_id
 	) u
-INNER JOIN (
+LEFT JOIN (
 	SELECT t1.target_cohort_id,
 		c1.comparator_cohort_id,
 		SUM(CASE 
@@ -103,7 +104,9 @@ INNER JOIN (
 			subject_id
 		) c1 ON t1.target_cohort_id = c1.comparator_cohort_id
 		AND t1.subject_id = c1.subject_id
+	WHERE t1.target_cohort_id != c1.comparator_cohort_id
 	GROUP BY t1.target_cohort_id,
 		c1.comparator_cohort_id
 	) i ON u.target_cohort_id = i.target_cohort_id
-	AND u.comparator_cohort_id = i.comparator_cohort_id;
+	AND u.comparator_cohort_id = i.comparator_cohort_id
+	ORDER BY u.target_cohort_id, u.comparator_cohort_id;

--- a/inst/sql/sql_server/CohortOverlap.sql
+++ b/inst/sql/sql_server/CohortOverlap.sql
@@ -1,22 +1,17 @@
-{DEFAULT @cohort_database_schema = cdm_optum_extended_dod_v1027.ohdsi_results} 
-{DEFAULT @cohort_table = cohort} 
-{DEFAULT @target_cohort_id = 10481 } 
-{DEFAULT @comparator_cohort_id = 12770 }
-
-SELECT target_cohort_id,
-	comparator_cohort_id,
-	union_counts.num_persons_in_either AS either_subjects,
-	union_counts.num_persons_in_both AS both_subjects,
-	union_counts.num_persons_in_t_only AS t_only_subjects,
-	union_counts.num_persons_in_c_only AS c_only_subjects,
-	intersection_counts.num_persons_in_t_before_c AS t_before_c_subjects,
-	intersection_counts.num_persons_in_c_before_t AS c_before_t_subjects,
-	intersection_counts.num_persons_in_t_c_sameday AS same_day_subjects,
-	intersection_counts.num_persons_t_in_c AS t_in_c_subjects,
-	intersection_counts.num_persons_c_in_t AS c_in_t_subjects
+SELECT u.target_cohort_id,
+	u.comparator_cohort_id,
+	u.num_persons_in_either AS either_subjects,
+	u.num_persons_in_both AS both_subjects,
+	u.num_persons_in_t_only AS t_only_subjects,
+	u.num_persons_in_c_only AS c_only_subjects,
+	i.num_persons_in_t_before_c AS t_before_c_subjects,
+	i.num_persons_in_c_before_t AS c_before_t_subjects,
+	i.num_persons_in_t_c_sameday AS same_day_subjects,
+	i.num_persons_t_in_c AS t_in_c_subjects,
+	i.num_persons_c_in_t AS c_in_t_subjects
 FROM (
-	SELECT target_cohort_id,
-		comparator_cohort_id,
+	SELECT t1.target_cohort_id,
+		c1.comparator_cohort_id,
 		COUNT(all_persons.subject_id) AS num_persons_in_either, --this is unique persons
 		SUM(CASE 
 				WHEN t1.subject_id IS NOT NULL
@@ -39,75 +34,76 @@ FROM (
 	FROM (
 		SELECT DISTINCT subject_id
 		FROM @cohort_database_schema.@cohort_table
-		WHERE cohort_definition_id IN (@target_cohort_id)
-			OR cohort_definition_id IN (@comparator_cohort_id)
+		WHERE cohort_definition_id IN (@target_cohort_ids)
+			OR cohort_definition_id IN (@comparator_cohort_ids)
 		) all_persons
 	LEFT JOIN (
 		SELECT DISTINCT cohort_definition_id target_cohort_id,
 			subject_id
 		FROM @cohort_database_schema.@cohort_table
-		WHERE cohort_definition_id IN (@target_cohort_id)
+		WHERE cohort_definition_id IN (@target_cohort_ids)
 		) t1 ON all_persons.subject_id = t1.subject_id
 	LEFT JOIN (
 		SELECT DISTINCT cohort_definition_id comparator_cohort_id,
 			subject_id
 		FROM @cohort_database_schema.@cohort_table
-		WHERE cohort_definition_id = @comparator_cohort_id
+		WHERE cohort_definition_id IN (@comparator_cohort_ids)
 		) c1 ON all_persons.subject_id = c1.subject_id
-	GROUP BY target_cohort_id,
-		comparator_cohort_id
-	) union_counts,
-	(
-		SELECT target_cohort_id,
-			comparator_cohort_id,
-			SUM(CASE 
-					WHEN t1.min_start < c1.min_start
-						THEN 1
-					ELSE 0
-					END) AS num_persons_in_t_before_c,
-			SUM(CASE 
-					WHEN c1.min_start < t1.min_start
-						THEN 1
-					ELSE 0
-					END) AS num_persons_in_c_before_t,
-			SUM(CASE 
-					WHEN c1.min_start = t1.min_start
-						THEN 1
-					ELSE 0
-					END) AS num_persons_in_t_c_sameday,
-			SUM(CASE 
-					WHEN t1.min_start >= c1.min_start
-						AND t1.min_start <= c1.min_end
-						THEN 1
-					ELSE 0
-					END) AS num_persons_t_in_c,
-			SUM(CASE 
-					WHEN c1.min_start >= t1.min_start
-						AND c1.min_start <= t1.min_end
-						THEN 1
-					ELSE 0
-					END) AS num_persons_c_in_t
-		FROM (
-			SELECT cohort_definition_id target_cohort_id,
-				subject_id,
-				MIN(cohort_start_date) AS min_start,
-				MIN(cohort_end_date) AS min_end
-			FROM @cohort_database_schema.@cohort_table
-			WHERE cohort_definition_id = @target_cohort_id
-			GROUP BY cohort_definition_id,
-				subject_id
-			) t1
-		INNER JOIN (
-			SELECT cohort_definition_id comparator_cohort_id,
-				subject_id,
-				MIN(cohort_start_date) AS min_start,
-				MIN(cohort_end_date) AS min_end
-			FROM @cohort_database_schema.@cohort_table
-			WHERE cohort_definition_id = @comparator_cohort_id
-			GROUP BY cohort_definition_id,
-				subject_id
-			) c1 ON t1.target_cohort_id = c1.comparator_cohort_id
-			AND t1.subject_id = c1.subject_id
-		GROUP BY target_cohort_id,
-			comparator_cohort_id
-		) intersection_counts;
+	GROUP BY t1.target_cohort_id,
+		c1.comparator_cohort_id
+	) u
+INNER JOIN (
+	SELECT t1.target_cohort_id,
+		c1.comparator_cohort_id,
+		SUM(CASE 
+				WHEN t1.min_start < c1.min_start
+					THEN 1
+				ELSE 0
+				END) AS num_persons_in_t_before_c,
+		SUM(CASE 
+				WHEN c1.min_start < t1.min_start
+					THEN 1
+				ELSE 0
+				END) AS num_persons_in_c_before_t,
+		SUM(CASE 
+				WHEN c1.min_start = t1.min_start
+					THEN 1
+				ELSE 0
+				END) AS num_persons_in_t_c_sameday,
+		SUM(CASE 
+				WHEN t1.min_start >= c1.min_start
+					AND t1.min_start <= c1.min_end
+					THEN 1
+				ELSE 0
+				END) AS num_persons_t_in_c,
+		SUM(CASE 
+				WHEN c1.min_start >= t1.min_start
+					AND c1.min_start <= t1.min_end
+					THEN 1
+				ELSE 0
+				END) AS num_persons_c_in_t
+	FROM (
+		SELECT cohort_definition_id target_cohort_id,
+			subject_id,
+			MIN(cohort_start_date) AS min_start,
+			MIN(cohort_end_date) AS min_end
+		FROM @cohort_database_schema.@cohort_table
+		WHERE cohort_definition_id IN (@target_cohort_ids)
+		GROUP BY cohort_definition_id,
+			subject_id
+		) t1
+	INNER JOIN (
+		SELECT cohort_definition_id comparator_cohort_id,
+			subject_id,
+			MIN(cohort_start_date) AS min_start,
+			MIN(cohort_end_date) AS min_end
+		FROM @cohort_database_schema.@cohort_table
+		WHERE cohort_definition_id IN (@comparator_cohort_ids)
+		GROUP BY cohort_definition_id,
+			subject_id
+		) c1 ON t1.target_cohort_id = c1.comparator_cohort_id
+		AND t1.subject_id = c1.subject_id
+	GROUP BY t1.target_cohort_id,
+		c1.comparator_cohort_id
+	) i ON u.target_cohort_id = i.target_cohort_id
+	AND u.comparator_cohort_id = i.comparator_cohort_id;

--- a/inst/sql/sql_server/CohortOverlap.sql
+++ b/inst/sql/sql_server/CohortOverlap.sql
@@ -1,9 +1,11 @@
-{DEFAULT @cohort_database_schema = cdm_optum_extended_dod_v1027.ohdsi_results}
-{DEFAULT @cohort_table = cohort}
-{DEFAULT @target_cohort_id = 10481}
-{DEFAULT @comparator_cohort_id = 12770}
+{DEFAULT @cohort_database_schema = cdm_optum_extended_dod_v1027.ohdsi_results} 
+{DEFAULT @cohort_table = cohort} 
+{DEFAULT @target_cohort_id = 10481 } 
+{DEFAULT @comparator_cohort_id = 12770 }
 
-SELECT union_counts.num_persons_in_either AS either_subjects,
+SELECT target_cohort_id,
+	comparator_cohort_id,
+	union_counts.num_persons_in_either AS either_subjects,
 	union_counts.num_persons_in_both AS both_subjects,
 	union_counts.num_persons_in_t_only AS t_only_subjects,
 	union_counts.num_persons_in_c_only AS c_only_subjects,
@@ -13,7 +15,9 @@ SELECT union_counts.num_persons_in_either AS either_subjects,
 	intersection_counts.num_persons_t_in_c AS t_in_c_subjects,
 	intersection_counts.num_persons_c_in_t AS c_in_t_subjects
 FROM (
-	SELECT COUNT(all_persons.subject_id) AS num_persons_in_either,
+	SELECT target_cohort_id,
+		comparator_cohort_id,
+		COUNT(all_persons.subject_id) AS num_persons_in_either, --this is unique persons
 		SUM(CASE 
 				WHEN t1.subject_id IS NOT NULL
 					AND c1.subject_id IS NOT NULL
@@ -35,26 +39,28 @@ FROM (
 	FROM (
 		SELECT DISTINCT subject_id
 		FROM @cohort_database_schema.@cohort_table
-		WHERE cohort_definition_id IN (
-				@target_cohort_id,
-				@comparator_cohort_id
-				)
+		WHERE cohort_definition_id IN (@target_cohort_id)
+			OR cohort_definition_id IN (@comparator_cohort_id)
 		) all_persons
 	LEFT JOIN (
-		SELECT DISTINCT subject_id
+		SELECT DISTINCT cohort_definition_id target_cohort_id,
+			subject_id
 		FROM @cohort_database_schema.@cohort_table
-		WHERE cohort_definition_id = @target_cohort_id
-		) t1
-		ON all_persons.subject_id = t1.subject_id
+		WHERE cohort_definition_id IN (@target_cohort_id)
+		) t1 ON all_persons.subject_id = t1.subject_id
 	LEFT JOIN (
-		SELECT DISTINCT subject_id
+		SELECT DISTINCT cohort_definition_id comparator_cohort_id,
+			subject_id
 		FROM @cohort_database_schema.@cohort_table
 		WHERE cohort_definition_id = @comparator_cohort_id
-		) c1
-		ON all_persons.subject_id = c1.subject_id
+		) c1 ON all_persons.subject_id = c1.subject_id
+	GROUP BY target_cohort_id,
+		comparator_cohort_id
 	) union_counts,
 	(
-		SELECT SUM(CASE 
+		SELECT target_cohort_id,
+			comparator_cohort_id,
+			SUM(CASE 
 					WHEN t1.min_start < c1.min_start
 						THEN 1
 					ELSE 0
@@ -82,20 +88,26 @@ FROM (
 					ELSE 0
 					END) AS num_persons_c_in_t
 		FROM (
-			SELECT subject_id,
+			SELECT cohort_definition_id target_cohort_id,
+				subject_id,
 				MIN(cohort_start_date) AS min_start,
 				MIN(cohort_end_date) AS min_end
 			FROM @cohort_database_schema.@cohort_table
 			WHERE cohort_definition_id = @target_cohort_id
-			GROUP BY subject_id
+			GROUP BY cohort_definition_id,
+				subject_id
 			) t1
 		INNER JOIN (
-			SELECT subject_id,
+			SELECT cohort_definition_id comparator_cohort_id,
+				subject_id,
 				MIN(cohort_start_date) AS min_start,
 				MIN(cohort_end_date) AS min_end
 			FROM @cohort_database_schema.@cohort_table
 			WHERE cohort_definition_id = @comparator_cohort_id
-			GROUP BY subject_id
-			) c1
-			ON t1.subject_id = c1.subject_id
+			GROUP BY cohort_definition_id,
+				subject_id
+			) c1 ON t1.target_cohort_id = c1.comparator_cohort_id
+			AND t1.subject_id = c1.subject_id
+		GROUP BY target_cohort_id,
+			comparator_cohort_id
 		) intersection_counts;


### PR DESCRIPTION
https://github.com/OHDSI/CohortDiagnostics/issues/420

Hey @azimov cohort overlap compares every cohort combination. Current implementation runs one query for every combination of n*(n-1) of cohorts. This has become bottle neck - as most of time is just I/O (99%).

Maybe this will help speed up?