### PR TITLE
Add markdown for suggests so R CMD check succeeds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Suggests:
   pool,
   purrr,
   RColorBrewer,
+  markdown,
   rmarkdown,
   RSQLite (>= 2.2.1),
   scales,


### PR DESCRIPTION
When running `rcmdcheck`, this initially fails with this issue:
```
   --- re-building ‘CohortDiagnosticsInPackageMode.Rmd’ using rmarkdown
   Warning in engine$weave(file, quiet = quiet, encoding = enc) :
     Pandoc (>= 1.12.3) not available. Falling back to R Markdown v1.
   Error: processing vignette 'CohortDiagnosticsInPackageMode.Rmd' failed with diagnostics:
   The 'markdown' package should be installed and declared as a dependency of the 'CohortDiagnostics' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
```
This pull request fixes that