### PR TITLE
Create a symbolic link to an sql directory when devtools::load is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ errorReportR.txt
 *log.txt
 inst/shiny/DiagnosticsExplorer/data/PreMerged.RData
 tests/testthat/testthat-problems.rds
+sql

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,8 @@ Suggests:
   shinyWidgets,
   testthat,
   withr,
-  zip
+  zip,
+  R.utils
 Remotes:
   ohdsi/Eunomia,
   ohdsi/FeatureExtraction,

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,9 @@
+# When devtools::load_all is run, create symbolic link for sql directory
+# Allows testing with devtools::test
+if (Sys.getenv("DEVTOOLS_LOAD") == "true") {
+  print("setting sql folder symobolic link")
+  packageRoot <- normalizePath(system.file("..", package = "CohortDiagnostics"))
+  # Create symbolic link so code can be used in devtools::test()
+  R.utils::createLink(link = file.path(packageRoot, "sql"), system.file("sql", package = "CohortDiagnostics"))
+  options("use.devtools.sql_shim" = TRUE)
+}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -6,7 +6,7 @@ env_exists <- function(varname) {
 # Function which warns user if an expected environment variable is not defined
 check_env <- function(varname) {
   if (!env_exists(varname)) {
-    warning(sprintf("Environment variable %s is not defined",varname))
+    warning(sprintf("Environment variable %s is not defined", varname))
   }
 }
 
@@ -22,7 +22,7 @@ folder <- tempfile(paste0("cd_test_", gsub("[^a-zA-Z]", "", .Platform$OS.type), 
 
 # On GitHub Actions, only run database tests on MacOS to avoid overloading database server:
 runDatabaseTests <- env_exists("CDM5_POSTGRESQL_SERVER") &&
- (!env_exists("GITHUB_ACTIONS") || Sys.getenv("RUNNER_OS", unset = "") == "macOS") 
+  (!env_exists("GITHUB_ACTIONS") || Sys.getenv("RUNNER_OS", unset = "") == "macOS")
 
 if (runDatabaseTests) {
   
@@ -37,7 +37,7 @@ if (runDatabaseTests) {
       unlink(jdbcDriverFolder, recursive = TRUE, force = TRUE)
     }, testthat::teardown_env())
   }
-  
+
   # Set connection details, and schema and table names --------------------------
   connectionDetails <- DatabaseConnector::createConnectionDetails(
     dbms = "postgresql",
@@ -45,7 +45,7 @@ if (runDatabaseTests) {
     password = URLdecode(Sys.getenv("CDM5_POSTGRESQL_PASSWORD")),
     server = Sys.getenv("CDM5_POSTGRESQL_SERVER"),
     pathToDriver = jdbcDriverFolder)
-  
+
   # Set database  schemas
 
   cdmDatabaseSchema <- "eunomia"
@@ -59,7 +59,7 @@ if (runDatabaseTests) {
 
   tempEmulationSchema <- NULL
   cohortDatabaseSchema <- cohortDiagnosticsSchema
-  
+
   # Clean up when exiting testing -----------------------------------
   withr::defer({
     connection <- DatabaseConnector::connect(connectionDetails = connectionDetails)
@@ -71,3 +71,11 @@ if (runDatabaseTests) {
     unlink(folder, recursive = TRUE, force = TRUE)
   }, testthat::teardown_env())
 }
+
+withr::defer({
+  if (getOption("use.devtools.sql_shim", FALSE)) {
+    # Remove symbolic link to sql folder created when devtools::test loads helpers
+    packageRoot <- normalizePath(system.file("..", package = "CohortDiagnostics"))
+    unlink(file.path(packageRoot, "sql"), recursive = FALSE)
+  }
+}, testthat::teardown_env())


### PR DESCRIPTION
Symlink sql file created on devtools::load

Note; will create problems for build with r cmd check so root level sql folder shouldn't be checked in.
Perhaps a solution is to make sure this is removed in package maintenance? I have added a check when the test functions finish but this isn't possible with `devtools::load_all()`