### PR TITLE
Update vignette to reflect changes in CohortGenerator

### DIFF
--- a/vignettes/RunningCohortDiagnostics.Rmd
+++ b/vignettes/RunningCohortDiagnostics.Rmd
@@ -114,7 +114,6 @@ cohortTableNames <- CohortGenerator::getCohortTableNames(cohortTable = cohortTab
 CohortGenerator::createCohortTables(connectionDetails = connectionDetails,
                                     cohortTableNames = cohortTableNames,
                                     cohortDatabaseSchema = "main",
-                                    createCohortStatsTables = TRUE,
                                     incremental = FALSE)
 
 # Generate the cohort set


### PR DESCRIPTION
We've removed the `createCohortStatsTables` option from CohortGenerator.