### PR TITLE
Fix for multiple runs on different databases

### DIFF
--- a/inst/shiny/DiagnosticsExplorer/ui.R
+++ b/inst/shiny/DiagnosticsExplorer/ui.R
@@ -179,7 +179,7 @@ sidebarMenu <-
       shinyWidgets::pickerInput(
         inputId = "database",
         label = "Database",
-        choices = database$databaseId,
+        choices = database$databaseId %>% unique(),
         selected = database$databaseId[1],
         multiple = FALSE,
         choicesOpt = list(style = rep_len("color: black;", 999)),
@@ -207,7 +207,7 @@ sidebarMenu <-
       shinyWidgets::pickerInput(
         inputId = "databases",
         label = "Database",
-        choices = database$databaseId,
+        choices = database$databaseId %>% unique(),
         selected = database$databaseId[1],
         multiple = TRUE,
         choicesOpt = list(style = rep_len("color: black;", 999)),


### PR DESCRIPTION
Caused when multiple runs of CohortDiagnostics writes to database meta-data multiple times.

This fix does not effect the main package codebase so does not need to result in a version number increase.