### PR TITLE
Characterization output are large - introduce minimum proportion 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,6 +66,6 @@ License: Apache License
 VignetteBuilder: knitr
 URL: https://ohdsi.github.io/CohortDiagnostics, https://github.com/OHDSI/CohortDiagnostics
 BugReports: https://github.com/OHDSI/CohortDiagnostics/issues
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Encoding: UTF-8
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@ Changes:
 
 10. Ensure that tests cases always use a continuous covariate
 
+11. New parameter minCharacterizationMean. This introduces a cut off for the output of FeatureExtraction. In the absence of the parameter the output would have atleast one row for every covariateId in the datasource  - most having very low count to be useful for diagnostics.
+
 Bug fixes:
 
 1. Fixed issue uploading results to postgres db caused by null values in primary key field. 

--- a/R/CohortCharacterizationDiagnostics.R
+++ b/R/CohortCharacterizationDiagnostics.R
@@ -216,7 +216,8 @@ executeCohortCharacterization <- function(connection,
                                           covariateValueContFileName = file.path(exportFolder, "temporal_covariate_value_dist.csv"),
                                           covariateRefFileName = file.path(exportFolder, "temporal_covariate_ref.csv"),
                                           analysisRefFileName = file.path(exportFolder, "temporal_analysis_ref.csv"),
-                                          timeRefFileName = file.path(exportFolder, "temporal_time_ref.csv")) {
+                                          timeRefFileName = file.path(exportFolder, "temporal_time_ref.csv"),
+                                          minCharacterizationMean = 0.001) {
   ParallelLogger::logInfo("Running ", jobName)
   startCohortCharacterization <- Sys.time()
   subset <- subsetToRequiredCohorts(
@@ -262,6 +263,7 @@ executeCohortCharacterization <- function(connection,
       analysisRefFileName = analysisRefFileName,
       timeRefFileName = timeRefFileName,
       counts = cohortCounts,
+      minCharacterizationMean = minCharacterizationMean,
       minCellCount = minCellCount
     )
   }

--- a/R/ExportCharacterization.R
+++ b/R/ExportCharacterization.R
@@ -24,14 +24,14 @@ exportCharacterization <- function(characteristics,
                                    analysisRefFileName,
                                    timeRefFileName = NULL,
                                    counts,
-                                   cutOff = 0.0001,
+                                   minCharacterizationMean = 0.001,
                                    minCellCount) {
   if (!"covariates" %in% names(characteristics)) {
     warning("No characterization output for submitted cohorts")
   } else if (dplyr::pull(dplyr::count(characteristics$covariateRef)) > 0) {
     characteristics$filteredCovariates <-
       characteristics$covariates %>%
-      dplyr::filter(.data$mean >= cutOff) %>%
+      dplyr::filter(.data$mean >= minCharacterizationMean) %>%
       dplyr::mutate(databaseId = !!databaseId) %>%
       dplyr::left_join(counts,
         by = c("cohortId", "databaseId"),

--- a/R/RunDiagnostics.R
+++ b/R/RunDiagnostics.R
@@ -124,14 +124,14 @@ getDefaultCovariateSettings <- function() {
 #' @param runCohortRelationship       Generate and export the cohort relationship? Cohort relationship checks the temporal
 #'                                    relationship between two or more cohorts.
 #' @param runTemporalCohortCharacterization   Generate and export the temporal cohort characterization?
-#'                                    Only records with values greater than 0.001 are returned.
+#'                                            Only records with values greater than 0.001 are returned.
 #' @param temporalCovariateSettings   Either an object of type \code{covariateSettings} as created using one of
 #'                                    the createTemporalCovariateSettings function in the FeatureExtraction package, or a list
 #'                                    of such objects.
 #' @param minCellCount                The minimum cell count for fields contains person counts or fractions.
 #' @param minCharacterizationMean     The minimum mean value for characterization output. Values below this will be cut off from output. This 
 #'                                    will help reduce the file size of the characterization output, but will remove information
-#'                                    on covariates that have very low values. The default is 0.001 (i.e. 0.1%)
+#'                                    on covariates that have very low values. The default is 0.001 (i.e. 0.1 percent)
 #' @param incremental                 Create only cohort diagnostics that haven't been created before?
 #' @param incrementalFolder           If \code{incremental = TRUE}, specify a folder where records are kept
 #'                                    of which cohort diagnostics has been executed.

--- a/R/RunDiagnostics.R
+++ b/R/RunDiagnostics.R
@@ -129,9 +129,9 @@ getDefaultCovariateSettings <- function() {
 #'                                    the createTemporalCovariateSettings function in the FeatureExtraction package, or a list
 #'                                    of such objects.
 #' @param minCellCount                The minimum cell count for fields contains person counts or fractions.
-#' @param minCharacterizationMean     The minimum mean value for characterization output. Values below this will be cut off from output.
-#'                                    This will help reduce the file size of the characterization output, but will remove information
-#'                                    on covaraiates that have very low values. The default is 0.001 (i.e. 0.1%)
+#' @param minCharacterizationMean     The minimum mean value for characterization output. Values below this will be cut off from output. This 
+#'                                    will help reduce the file size of the characterization output, but will remove information
+#'                                    on covariates that have very low values. The default is 0.001 (i.e. 0.1%)
 #' @param incremental                 Create only cohort diagnostics that haven't been created before?
 #' @param incrementalFolder           If \code{incremental = TRUE}, specify a folder where records are kept
 #'                                    of which cohort diagnostics has been executed.

--- a/R/RunDiagnostics.R
+++ b/R/RunDiagnostics.R
@@ -129,6 +129,9 @@ getDefaultCovariateSettings <- function() {
 #'                                    the createTemporalCovariateSettings function in the FeatureExtraction package, or a list
 #'                                    of such objects.
 #' @param minCellCount                The minimum cell count for fields contains person counts or fractions.
+#' @param minCharacterizationMean     The minimum mean value for characterization output. Values below this will be cut off from output.
+#'                                    This will help reduce the file size of the characterization output, but will remove information
+#'                                    on covaraiates that have very low values. The default is 0.001 (i.e. 0.1%)
 #' @param incremental                 Create only cohort diagnostics that haven't been created before?
 #' @param incrementalFolder           If \code{incremental = TRUE}, specify a folder where records are kept
 #'                                    of which cohort diagnostics has been executed.
@@ -204,6 +207,7 @@ executeDiagnostics <- function(cohortDefinitionSet,
                                runTemporalCohortCharacterization = TRUE,
                                temporalCovariateSettings = getDefaultCovariateSettings(),
                                minCellCount = 5,
+                               minCharacterizationMean = 0.01,
                                incremental = FALSE,
                                incrementalFolder = file.path(exportFolder, "incremental")) {
   
@@ -220,6 +224,7 @@ executeDiagnostics <- function(cohortDefinitionSet,
       runIncidenceRate = argumentsAtDiagnosticsInitiation$runIncidenceRate,
       runTemporalCohortCharacterization = argumentsAtDiagnosticsInitiation$runTemporalCohortCharacterization,
       minCellCount = argumentsAtDiagnosticsInitiation$minCellCount,
+      minCharacterizationMean = argumentsAtDiagnosticsInitiation$minCharacterizationMean,
       incremental = argumentsAtDiagnosticsInitiation$incremental,
       temporalCovariateSettings = argumentsAtDiagnosticsInitiation$temporalCovariateSettings
     ) %>%
@@ -289,6 +294,8 @@ executeDiagnostics <- function(cohortDefinitionSet,
   )
   minCellCount <- utils::type.convert(minCellCount, as.is = TRUE)
   checkmate::assertInteger(x = minCellCount, lower = 0, add = errorMessage)
+  minCharacterizationMean <- utils::type.convert(minCharacterizationMean, as.is = TRUE)
+  checkmate::assertNumeric(x = minCharacterizationMean, lower = 0, add = errorMessage)
   checkmate::assertLogical(incremental, add = errorMessage)
   
   if (any(
@@ -682,7 +689,8 @@ executeDiagnostics <- function(cohortDefinitionSet,
       covariateValueContFileName = file.path(exportFolder, "temporal_covariate_value_dist.csv"),
       covariateRefFileName = file.path(exportFolder, "temporal_covariate_ref.csv"),
       analysisRefFileName = file.path(exportFolder, "temporal_analysis_ref.csv"),
-      timeRefFileName = file.path(exportFolder, "temporal_time_ref.csv")
+      timeRefFileName = file.path(exportFolder, "temporal_time_ref.csv"),
+      minCharacterizationMean = minCharacterizationMean
     )
   }
   

--- a/man/executeDiagnostics.Rd
+++ b/man/executeDiagnostics.Rd
@@ -110,9 +110,9 @@ of such objects.}
 
 \item{minCellCount}{The minimum cell count for fields contains person counts or fractions.}
 
-\item{minCharacterizationMean}{The minimum mean value for characterization output. Values below this will be cut off from output.
-This will help reduce the file size of the characterization output, but will remove information
-on covaraiates that have very low values. The default is 0.001 (i.e. 0.1%)}
+\item{minCharacterizationMean}{The minimum mean value for characterization output. Values below this will be cut off from output. This 
+will help reduce the file size of the characterization output, but will remove information
+on covariates that have very low values. The default is 0.001 (i.e. 0.1%)}
 
 \item{incremental}{Create only cohort diagnostics that haven't been created before?}
 

--- a/man/executeDiagnostics.Rd
+++ b/man/executeDiagnostics.Rd
@@ -31,6 +31,7 @@ executeDiagnostics(
   runTemporalCohortCharacterization = TRUE,
   temporalCovariateSettings = getDefaultCovariateSettings(),
   minCellCount = 5,
+  minCharacterizationMean = 0.01,
   incremental = FALSE,
   incrementalFolder = file.path(exportFolder, "incremental")
 )
@@ -108,6 +109,10 @@ the createTemporalCovariateSettings function in the FeatureExtraction package, o
 of such objects.}
 
 \item{minCellCount}{The minimum cell count for fields contains person counts or fractions.}
+
+\item{minCharacterizationMean}{The minimum mean value for characterization output. Values below this will be cut off from output.
+This will help reduce the file size of the characterization output, but will remove information
+on covaraiates that have very low values. The default is 0.001 (i.e. 0.1%)}
 
 \item{incremental}{Create only cohort diagnostics that haven't been created before?}
 

--- a/man/executeDiagnostics.Rd
+++ b/man/executeDiagnostics.Rd
@@ -112,7 +112,7 @@ of such objects.}
 
 \item{minCharacterizationMean}{The minimum mean value for characterization output. Values below this will be cut off from output. This 
 will help reduce the file size of the characterization output, but will remove information
-on covariates that have very low values. The default is 0.001 (i.e. 0.1%)}
+on covariates that have very low values. The default is 0.001 (i.e. 0.1 percent)}
 
 \item{incremental}{Create only cohort diagnostics that haven't been created before?}
 


### PR DESCRIPTION
to reduce the file size

We already had this parameter called cutoff in exportCharacterization. So it is not a new functionality. This PR just makes it more transparent and available to the end user, instead of being hard coded.

Ideally should be in Feature Extraction. Then it can be filtered at the database level, instead of at the client level https://github.com/OHDSI/FeatureExtraction/issues/174