### PR TITLE
Refacatored chunking in feature extraction output

### DIFF
--- a/R/CohortCharacterizationDiagnostics.R
+++ b/R/CohortCharacterizationDiagnostics.R
@@ -22,176 +22,162 @@ getCohortCharacteristics <- function(connectionDetails = NULL,
                                      cohortTable = "cohort",
                                      cohortIds,
                                      cdmVersion = 5,
-                                     covariateSettings,
-                                     batchSize = getOption("CohortDiagnostics-FE-batch-size", default = 5)) {
+                                     covariateSettings) {
   startTime <- Sys.time()
   if (is.null(connection)) {
     connection <- DatabaseConnector::connect(connectionDetails)
     on.exit(DatabaseConnector::disconnect(connection))
   }
   results <- Andromeda::andromeda()
-  for (start in seq(1, length(cohortIds), by = batchSize)) {
-    end <- min(start + batchSize - 1, length(cohortIds))
-    if (length(cohortIds) > batchSize) {
-      ParallelLogger::logInfo(sprintf(
-        "Batch characterization. Processing cohorts %s through %s",
-        start,
-        end
-      ))
-    }
-    featureExtractionOutput <-
-      FeatureExtraction::getDbCovariateData(
-        connection = connection,
-        oracleTempSchema = tempEmulationSchema,
-        cdmDatabaseSchema = cdmDatabaseSchema,
-        cohortDatabaseSchema = cohortDatabaseSchema,
-        cdmVersion = cdmVersion,
-        cohortTable = cohortTable,
-        cohortId = cohortIds[start:end],
-        covariateSettings = covariateSettings,
-        aggregated = TRUE
-      )
-
-    populationSize <-
-      attr(x = featureExtractionOutput, which = "metaData")$populationSize
-    populationSize <-
-      dplyr::tibble(
-        cohortId = names(populationSize) %>% as.numeric(),
-        populationSize = populationSize
-      )
-
-    if (!"analysisRef" %in% names(results)) {
-      results$analysisRef <- featureExtractionOutput$analysisRef
-    }
-    if (!"covariateRef" %in% names(results)) {
-      results$covariateRef <- featureExtractionOutput$covariateRef
-    } else {
-      covariateIds <- results$covariateRef %>%
-        dplyr::select(.data$covariateId)
-      Andromeda::appendToTable(
-        results$covariateRef,
-        featureExtractionOutput$covariateRef %>%
-          dplyr::anti_join(covariateIds, by = "covariateId", copy = TRUE)
-      )
-    }
-    if ("timeRef" %in% names(featureExtractionOutput) &&
+  
+  featureExtractionOutput <-
+    FeatureExtraction::getDbCovariateData(
+      connection = connection,
+      oracleTempSchema = tempEmulationSchema,
+      cdmDatabaseSchema = cdmDatabaseSchema,
+      cohortDatabaseSchema = cohortDatabaseSchema,
+      cdmVersion = cdmVersion,
+      cohortTable = cohortTable,
+      cohortId = cohortIds,
+      covariateSettings = covariateSettings,
+      aggregated = TRUE
+    )
+  
+  populationSize <-
+    attr(x = featureExtractionOutput, which = "metaData")$populationSize
+  populationSize <-
+    dplyr::tibble(cohortId = names(populationSize) %>% as.numeric(),
+                  populationSize = populationSize)
+  
+  if (!"analysisRef" %in% names(results)) {
+    results$analysisRef <- featureExtractionOutput$analysisRef
+  }
+  if (!"covariateRef" %in% names(results)) {
+    results$covariateRef <- featureExtractionOutput$covariateRef
+  } else {
+    covariateIds <- results$covariateRef %>%
+      dplyr::select(.data$covariateId)
+    Andromeda::appendToTable(
+      results$covariateRef,
+      featureExtractionOutput$covariateRef %>%
+        dplyr::anti_join(covariateIds, by = "covariateId", copy = TRUE)
+    )
+  }
+  if ("timeRef" %in% names(featureExtractionOutput) &&
       !"timeRef" %in% names(results)) {
-      results$timeRef <- featureExtractionOutput$timeRef
-    }
-
-    if ("covariates" %in% names(featureExtractionOutput) &&
+    results$timeRef <- featureExtractionOutput$timeRef
+  }
+  
+  if ("covariates" %in% names(featureExtractionOutput) &&
       dplyr::pull(dplyr::count(featureExtractionOutput$covariates)) > 0) {
-      covariates <- featureExtractionOutput$covariates %>%
-        dplyr::rename(cohortId = .data$cohortDefinitionId) %>%
-        dplyr::left_join(populationSize, by = "cohortId", copy = TRUE) %>%
-        dplyr::mutate(p = .data$sumValue / .data$populationSize)
-
-      if (nrow(covariates %>%
-        dplyr::filter(.data$p > 1) %>%
-        dplyr::collect()) > 0) {
-        stop(
-          paste0(
-            "During characterization, population size (denominator) was found to be smaller than features Value (numerator).",
-            "- this may have happened because of an error in Feature generation process. Please contact the package developer."
-          )
+    covariates <- featureExtractionOutput$covariates %>%
+      dplyr::rename(cohortId = .data$cohortDefinitionId) %>%
+      dplyr::left_join(populationSize, by = "cohortId", copy = TRUE) %>%
+      dplyr::mutate(p = .data$sumValue / .data$populationSize)
+    
+    if (nrow(covariates %>%
+             dplyr::filter(.data$p > 1) %>%
+             dplyr::collect()) > 0) {
+      stop(
+        paste0(
+          "During characterization, population size (denominator) was found to be smaller than features Value (numerator).",
+          "- this may have happened because of an error in Feature generation process. Please contact the package developer."
         )
-      }
-
-      covariates <- covariates %>%
-        dplyr::mutate(sd = sqrt(.data$p * (1 - .data$p))) %>%
-        dplyr::select(-.data$p) %>%
-        dplyr::rename(mean = .data$averageValue) %>%
-        dplyr::select(-.data$populationSize)
-
-      if (FeatureExtraction::isTemporalCovariateData(featureExtractionOutput)) {
-        covariates <- covariates %>%
-          dplyr::select(
-            .data$cohortId,
-            .data$timeId,
-            .data$covariateId,
-            .data$sumValue,
-            .data$mean,
-            .data$sd
-          )
-          if (length(is.na(covariates$timeId)) > 0) {
-            covariates[is.na(covariates$timeId),]$timeId <- -1
-          }
-      } else {
-        covariates <- covariates %>%
-          dplyr::mutate(timeId = 0) %>%
-          dplyr::select(
-            .data$cohortId,
-            .data$timeId,
-            .data$covariateId,
-            .data$sumValue,
-            .data$mean,
-            .data$sd
-          ) %>%
-          dplyr::mutate(timeId = 0)
-      }
-      if ("covariates" %in% names(results)) {
-        Andromeda::appendToTable(results$covariates, covariates)
-      } else {
-        results$covariates <- covariates
-      }
+      )
     }
-
-    if ("covariatesContinuous" %in% names(featureExtractionOutput) &&
-      dplyr::pull(dplyr::count(featureExtractionOutput$covariatesContinuous)) > 0) {
-      covariates <- featureExtractionOutput$covariatesContinuous %>%
-        dplyr::rename(
-          mean = .data$averageValue,
-          sd = .data$standardDeviation,
-          cohortId = .data$cohortDefinitionId
+    
+    covariates <- covariates %>%
+      dplyr::mutate(sd = sqrt(.data$p * (1 - .data$p))) %>%
+      dplyr::select(-.data$p) %>%
+      dplyr::rename(mean = .data$averageValue) %>%
+      dplyr::select(-.data$populationSize)
+    
+    if (FeatureExtraction::isTemporalCovariateData(featureExtractionOutput)) {
+      covariates <- covariates %>%
+        dplyr::select(
+          .data$cohortId,
+          .data$timeId,
+          .data$covariateId,
+          .data$sumValue,
+          .data$mean,
+          .data$sd
         )
-      covariatesContinuous <- covariates
-      if (FeatureExtraction::isTemporalCovariateData(featureExtractionOutput)) {
-        covariates <- covariates %>%
-          dplyr::mutate(sumValue = -1) %>%
-          dplyr::select(
-            .data$cohortId,
-            .data$timeId,
-            .data$covariateId,
-            .data$sumValue,
-            .data$mean,
-            .data$sd
-          )
-          if (length(is.na(covariates$timeId)) > 0) {
-            covariates[is.na(covariates$timeId),]$timeId <- -1
-          }
-      } else {
-        covariates <- covariates %>%
-          dplyr::mutate(sumValue = -1,
-                        timeId = 0) %>%
-          dplyr::select(
-            .data$cohortId,
-            .data$timeId,
-            .data$covariateId,
-            .data$sumValue,
-            .data$mean,
-            .data$sd
-          )
+      if (length(is.na(covariates$timeId)) > 0) {
+        covariates[is.na(covariates$timeId), ]$timeId <- -1
       }
-      if ("covariates" %in% names(results)) {
-        Andromeda::appendToTable(results$covariates, covariates)
-      } else {
-        results$covariates <- covariates
-      }
-      if ("covariatesContinuous" %in% names(results)) {
-        Andromeda::appendToTable(results$covariatesContinuous, covariatesContinuous)
-      } else {
-        results$covariatesContinuous <- covariatesContinuous
-      }
+    } else {
+      covariates <- covariates %>%
+        dplyr::mutate(timeId = 0) %>%
+        dplyr::select(
+          .data$cohortId,
+          .data$timeId,
+          .data$covariateId,
+          .data$sumValue,
+          .data$mean,
+          .data$sd
+        ) %>%
+        dplyr::mutate(timeId = 0)
+    }
+    if ("covariates" %in% names(results)) {
+      Andromeda::appendToTable(results$covariates, covariates)
+    } else {
+      results$covariates <- covariates
     }
   }
-
+  
+  if ("covariatesContinuous" %in% names(featureExtractionOutput) &&
+      dplyr::pull(dplyr::count(featureExtractionOutput$covariatesContinuous)) > 0) {
+    covariates <- featureExtractionOutput$covariatesContinuous %>%
+      dplyr::rename(
+        mean = .data$averageValue,
+        sd = .data$standardDeviation,
+        cohortId = .data$cohortDefinitionId
+      )
+    covariatesContinuous <- covariates
+    if (FeatureExtraction::isTemporalCovariateData(featureExtractionOutput)) {
+      covariates <- covariates %>%
+        dplyr::mutate(sumValue = -1) %>%
+        dplyr::select(
+          .data$cohortId,
+          .data$timeId,
+          .data$covariateId,
+          .data$sumValue,
+          .data$mean,
+          .data$sd
+        )
+      if (length(is.na(covariates$timeId)) > 0) {
+        covariates[is.na(covariates$timeId), ]$timeId <- -1
+      }
+    } else {
+      covariates <- covariates %>%
+        dplyr::mutate(sumValue = -1,
+                      timeId = 0) %>%
+        dplyr::select(
+          .data$cohortId,
+          .data$timeId,
+          .data$covariateId,
+          .data$sumValue,
+          .data$mean,
+          .data$sd
+        )
+    }
+    if ("covariates" %in% names(results)) {
+      Andromeda::appendToTable(results$covariates, covariates)
+    } else {
+      results$covariates <- covariates
+    }
+    if ("covariatesContinuous" %in% names(results)) {
+      Andromeda::appendToTable(results$covariatesContinuous, covariatesContinuous)
+    } else {
+      results$covariatesContinuous <- covariatesContinuous
+    }
+  }
+  
   delta <- Sys.time() - startTime
-  ParallelLogger::logInfo(
-    "Cohort characterization took ",
-    signif(delta, 3),
-    " ",
-    attr(delta, "units")
-  )
+  ParallelLogger::logInfo("Cohort characterization took ",
+                          signif(delta, 3),
+                          " ",
+                          attr(delta, "units"))
   return(results)
 }
 
@@ -216,7 +202,8 @@ executeCohortCharacterization <- function(connection,
                                           covariateValueContFileName = file.path(exportFolder, "temporal_covariate_value_dist.csv"),
                                           covariateRefFileName = file.path(exportFolder, "temporal_covariate_ref.csv"),
                                           analysisRefFileName = file.path(exportFolder, "temporal_analysis_ref.csv"),
-                                          timeRefFileName = file.path(exportFolder, "temporal_time_ref.csv")) {
+                                          timeRefFileName = file.path(exportFolder, "temporal_time_ref.csv"),
+                                          batchSize = getOption("CohortDiagnostics-FE-batch-size", default = 5)) {
   ParallelLogger::logInfo("Running ", jobName)
   startCohortCharacterization <- Sys.time()
   subset <- subsetToRequiredCohorts(
@@ -226,11 +213,11 @@ executeCohortCharacterization <- function(connection,
     incremental = incremental,
     recordKeepingFile = recordKeepingFile
   )
-
+  
   if (incremental &&
-    (length(instantiatedCohorts) - nrow(subset)) > 0) {
+      (length(instantiatedCohorts) - nrow(subset)) > 0) {
     ParallelLogger::logInfo(sprintf(
-      "Skipping %s cohorts in incremental mode.",
+      "Skipping %s instantiated cohorts in incremental mode.",
       length(instantiatedCohorts) - nrow(subset)
     ))
   }
@@ -239,45 +226,74 @@ executeCohortCharacterization <- function(connection,
       "Starting large scale characterization of %s cohort(s)",
       nrow(subset)
     ))
-    characteristics <-
-      getCohortCharacteristics(
-        connection = connection,
-        cdmDatabaseSchema = cdmDatabaseSchema,
-        tempEmulationSchema = tempEmulationSchema,
-        cohortDatabaseSchema = cohortDatabaseSchema,
-        cohortTable = cohortTable,
-        cohortIds = subset$cohortId,
-        covariateSettings = covariateSettings,
-        cdmVersion = cdmVersion
+    
+    for (start in seq(1, nrow(subset), by = batchSize)) {
+      end <- min(start + batchSize - 1, nrow(subset))
+      if (nrow(subset) > batchSize) {
+        ParallelLogger::logInfo(
+          sprintf(
+            "Batch characterization. Processing rows %s through %s of total %s.",
+            start,
+            end,
+            nrow(subset)
+          )
+        )
+      }
+      
+      characteristics <-
+        getCohortCharacteristics(
+          connection = connection,
+          cdmDatabaseSchema = cdmDatabaseSchema,
+          tempEmulationSchema = tempEmulationSchema,
+          cohortDatabaseSchema = cohortDatabaseSchema,
+          cohortTable = cohortTable,
+          cohortIds = subset[start:end, ]$cohortId,
+          covariateSettings = covariateSettings,
+          cdmVersion = cdmVersion
+        )
+      
+      on.exit(Andromeda::close(characteristics), add = TRUE)
+      exportCharacterization(
+        characteristics = characteristics,
+        databaseId = databaseId,
+        incremental = incremental,
+        covariateValueFileName = covariateValueFileName,
+        covariateValueContFileName = covariateValueContFileName,
+        covariateRefFileName = covariateRefFileName,
+        analysisRefFileName = analysisRefFileName,
+        timeRefFileName = timeRefFileName,
+        counts = cohortCounts,
+        minCellCount = minCellCount
       )
-
-    on.exit(Andromeda::close(characteristics), add = TRUE)
-    exportCharacterization(
-      characteristics = characteristics,
-      databaseId = databaseId,
-      incremental = incremental,
-      covariateValueFileName = covariateValueFileName,
-      covariateValueContFileName = covariateValueContFileName,
-      covariateRefFileName = covariateRefFileName,
-      analysisRefFileName = analysisRefFileName,
-      timeRefFileName = timeRefFileName,
-      counts = cohortCounts,
-      minCellCount = minCellCount
-    )
+      
+      recordTasksDone(
+        cohortId = subset[start:end, ]$cohortId,
+        task = task,
+        checksum = subset[start:end, ]$checksum,
+        recordKeepingFile = recordKeepingFile,
+        incremental = incremental
+      )
+      
+      deltaIteration <- Sys.time() - startCohortCharacterization
+      ParallelLogger::logInfo(
+        "    - Running Cohort Characterization iteration with batchsize ",
+        batchSize,
+        " from row number ",
+        start,
+        " to ",
+        end,
+        " took ",
+        signif(deltaIteration, 3),
+        " ",
+        attr(deltaIteration, "units")
+      )
+    }
   }
-
-  recordTasksDone(
-    cohortId = subset$cohortId,
-    task = task,
-    checksum = subset$checksum,
-    recordKeepingFile = recordKeepingFile,
-    incremental = incremental
-  )
   delta <- Sys.time() - startCohortCharacterization
-  ParallelLogger::logInfo(
-    "Running ", jobName, " took",
-    signif(delta, 3),
-    " ",
-    attr(delta, "units")
-  )
+  ParallelLogger::logInfo("Running ",
+                          jobName,
+                          " took",
+                          signif(delta, 3),
+                          " ",
+                          attr(delta, "units"))
 }

--- a/R/CohortCharacterizationDiagnostics.R
+++ b/R/CohortCharacterizationDiagnostics.R
@@ -34,7 +34,7 @@ getCohortCharacteristics <- function(connectionDetails = NULL,
     exportFolder,
     taskName = "getDbCovariateData",
     parent = "getCohortCharacteristics",
-    cohortIds = cohortIds[start:end],
+    cohortIds = cohortIds,
     expr = {
       featureExtractionOutput <-
         FeatureExtraction::getDbCovariateData(

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -37,8 +37,10 @@ loadTestCohortDefinitionSet <- function(cohortIds = NULL) {
   if (!is.null(cohortIds)) {
     cohortDefinitionSet <- cohortDefinitionSet %>% dplyr::filter(.data$cohortId %in% cohortIds)
   }
+  
+  cohortDefinitionSet$checksum <- computeChecksum(cohortDefinitionSet$sql)
 
-  cohortDefinitionSet
+  return(cohortDefinitionSet)
 }
 
 #' Use to create test fixture for shiny tests

--- a/tests/testthat/test-Characterization.R
+++ b/tests/testthat/test-Characterization.R
@@ -8,7 +8,6 @@ test_that("Execute and export characterization", {
     recordKeepingFile <- tempfile(fileext="csv")
     dir.create(exportFolder)
     on.exit(unlink(exportFolder), add = TRUE)
-
     cohortTableNames <- CohortGenerator::getCohortTableNames(cohortTable = cohortTable)
     # Next create the tables on the database
     CohortGenerator::createCohortTables(
@@ -68,7 +67,7 @@ test_that("Execute and export characterization", {
                                   recordKeepingFile = recordKeepingFile,
                                   task = "runTemporalCohortCharacterization",
                                   jobName = "Temporal Cohort characterization")
-
+    
     # Check all files are created
     checkmate::expect_file_exists(file.path(exportFolder, "temporal_covariate_ref.csv"))
     checkmate::expect_file_exists(file.path(exportFolder, "temporal_analysis_ref.csv"))
@@ -105,29 +104,6 @@ test_that("Execute and export characterization", {
     tdata <- readr::read_csv(file.path(exportFolder, "temporal_time_ref.csv"))
     expect_false(any(is.na(tdata$time_id) | is.null(tdata$time_id)))
     
-    
-    unlink(x = file.path(exportFolder, "temporal_covariate_value_dist.csv"), recursive = TRUE, force = TRUE)
-    unlink(x = file.path(exportFolder, "temporal_covariate_value.csv"), recursive = TRUE, force = TRUE)
-    unlink(x = file.path(exportFolder, "temporal_time_ref.csv"), recursive = TRUE, force = TRUE)
-    executeCohortCharacterization(connection = tConnection,
-                                  databaseId = "Testdb",
-                                  exportFolder = exportFolder,
-                                  cdmDatabaseSchema = cdmDatabaseSchema,
-                                  cohortDatabaseSchema = cohortDatabaseSchema,
-                                  cohortTable = cohortTable,
-                                  covariateSettings = temporalCovariateSettings,
-                                  tempEmulationSchema = tempEmulationSchema,
-                                  cdmVersion = 5,
-                                  cohorts = cohortDefinitionSet,
-                                  cohortCounts = cohortCounts,
-                                  minCellCount = 5,
-                                  instantiatedCohorts = cohortDefinitionSet$cohortId,
-                                  incremental = TRUE,
-                                  recordKeepingFile = recordKeepingFile,
-                                  task = "runTemporalCohortCharacterization",
-                                  jobName = "Temporal Cohort characterization")
-    
-    
     # check if subset works
     subset <- subsetToRequiredCohorts(
       cohorts = cohortDefinitionSet,
@@ -135,20 +111,6 @@ test_that("Execute and export characterization", {
       incremental = TRUE,
       recordKeepingFile = recordKeepingFile
     )
-    
-    #should not have the cohorts that were previously run
-    testthat::expect_equal(object = nrow(subset),
-                           expected = 0)
-    
-    # should not have data from first run cohorts --it was deleted, and second run is in incremental
-    tdata <-
-      readr::read_csv(file.path(exportFolder, "temporal_covariate_value.csv"))
-    testthat::expect_equal(object = nrow(tdata %>%
-                                           dplyr::filter(
-                                             .data$cohort_id %in% c(cohortDefinitionSet[1:3, ]$cohortId)
-                                           )),
-                           expected = 0)
-    
   })
 
 })

--- a/tests/testthat/test-Characterization.R
+++ b/tests/testthat/test-Characterization.R
@@ -93,24 +93,35 @@ test_that("Execute and export characterization", {
                                            )),
                            expected = 0)
     
+    # finish the rest of characterization
+    executeCohortCharacterization(connection = tConnection,
+                                  databaseId = "Testdb",
+                                  exportFolder = exportFolder,
+                                  cdmDatabaseSchema = cdmDatabaseSchema,
+                                  cohortDatabaseSchema = cohortDatabaseSchema,
+                                  cohortTable = cohortTable,
+                                  covariateSettings = temporalCovariateSettings,
+                                  tempEmulationSchema = tempEmulationSchema,
+                                  cdmVersion = 5,
+                                  cohorts = cohortDefinitionSet,
+                                  cohortCounts = cohortCounts,
+                                  minCellCount = 5,
+                                  instantiatedCohorts = cohortDefinitionSet$cohortId,
+                                  incremental = TRUE,
+                                  recordKeepingFile = recordKeepingFile,
+                                  task = "runTemporalCohortCharacterization",
+                                  jobName = "Temporal Cohort characterization")
+    
     # Check no time ids are NA/NULL
     tdata <- readr::read_csv(file.path(exportFolder, "temporal_covariate_value_dist.csv"))
     expect_false(any(is.na(tdata$time_id) | is.null(tdata$time_id)))
-
+    
     tdata <- readr::read_csv(file.path(exportFolder, "temporal_covariate_value.csv"))
     expect_false(any(is.na(tdata$time_id) | is.null(tdata$time_id)))
-
+    
     # It would make no sense if there were NA values here
     tdata <- readr::read_csv(file.path(exportFolder, "temporal_time_ref.csv"))
     expect_false(any(is.na(tdata$time_id) | is.null(tdata$time_id)))
     
-    # check if subset works
-    subset <- subsetToRequiredCohorts(
-      cohorts = cohortDefinitionSet,
-      task = "runTemporalCohortCharacterization",
-      incremental = TRUE,
-      recordKeepingFile = recordKeepingFile
-    )
   })
-
 })


### PR DESCRIPTION
When running a large batch - e.g. 100+, previous design would only write to csv and incremental log after all 100+ were complete

This was causing loss of compute during disconnection, failure etc.

This PR makes chunking consistent across CohortDiagnostics