### PR TITLE
concept_id of int instead of big int in data type

### DIFF
--- a/R/Incremental.R
+++ b/R/Incremental.R
@@ -266,6 +266,10 @@ saveIncremental <- function(data, fileName, ...) {
       lazy = FALSE
     )
     if ((nrow(previousData)) > 0) {
+      if("databaseId" %in% colnames(previousData)) {
+        previousData$databaseId <- as.character(previousData$databaseId)
+      }
+
       if (!length(list(...)) == 0) {
         idx <- getKeyIndex(list(...), previousData)
       } else {

--- a/R/Incremental.R
+++ b/R/Incremental.R
@@ -266,8 +266,8 @@ saveIncremental <- function(data, fileName, ...) {
       lazy = FALSE
     )
     if ((nrow(previousData)) > 0) {
-      if("databaseId" %in% colnames(previousData)) {
-        previousData$databaseId <- as.character(previousData$databaseId)
+      if("database_id" %in% colnames(previousData)) {
+        previousData$database_id <- as.character(previousData$database_id)
       }
 
       if (!length(list(...)) == 0) {

--- a/inst/settings/resultsDataModelSpecification.csv
+++ b/inst/settings/resultsDataModelSpecification.csv
@@ -95,7 +95,7 @@ cohort_summary_stats,cohort_id,bigint,Yes,Yes,No,Yes,No,No,No
 cohort_summary_stats,mode_id,bigint,Yes,Yes,No,Yes,No,No,No
 cohort_summary_stats,base_count,float,Yes,No,No,Yes,Yes,No,No
 cohort_summary_stats,final_count,float,Yes,No,No,Yes,Yes,No,No
-concept,concept_id,int,Yes,Yes,No,Yes,No,Yes,No
+concept,concept_id,bigint,Yes,Yes,No,Yes,No,Yes,No
 concept,concept_name,varchar(255),Yes,No,No,Yes,No,Yes,No
 concept,domain_id,varchar(20),Yes,No,No,Yes,No,Yes,No
 concept,vocabulary_id,varchar(50),Yes,No,No,Yes,No,Yes,No

--- a/inst/shiny/DiagnosticsExplorer/data/resultsDataModelSpecification.csv
+++ b/inst/shiny/DiagnosticsExplorer/data/resultsDataModelSpecification.csv
@@ -95,7 +95,7 @@ cohort_summary_stats,cohort_id,bigint,Yes,Yes,No,Yes,No,No,No
 cohort_summary_stats,mode_id,bigint,Yes,Yes,No,Yes,No,No,No
 cohort_summary_stats,base_count,float,Yes,No,No,Yes,Yes,No,No
 cohort_summary_stats,final_count,float,Yes,No,No,Yes,Yes,No,No
-concept,concept_id,int,Yes,Yes,No,Yes,No,Yes,No
+concept,concept_id,bigint,Yes,Yes,No,Yes,No,Yes,No
 concept,concept_name,varchar(255),Yes,No,No,Yes,No,Yes,No
 concept,domain_id,varchar(20),Yes,No,No,Yes,No,Yes,No
 concept,vocabulary_id,varchar(50),Yes,No,No,Yes,No,Yes,No

--- a/inst/sql/sql_server/CreateConceptIdTable.sql
+++ b/inst/sql/sql_server/CreateConceptIdTable.sql
@@ -1,2 +1,2 @@
 DROP TABLE IF EXISTS @table_name;
-CREATE TABLE @table_name (concept_id INT);
+CREATE TABLE @table_name (concept_id BIGINT);


### PR DESCRIPTION
AN issue was found where concept ids were overlflowing in concept set analysis - this aims to fix that bug

Fixes #717

 also, database_id forced to be read as a character to prevent type issues when merging with old data