### PR TITLE
Fix to remove existing files if batch operations are ran outside incremental mode

### DIFF
--- a/R/CohortCharacterizationDiagnostics.R
+++ b/R/CohortCharacterizationDiagnostics.R
@@ -220,6 +220,17 @@ executeCohortCharacterization <- function(connection,
     recordKeepingFile = recordKeepingFile
   )
 
+  if (!incremental) {
+    for (outputFile in c(covariateValueFileName, covariateValueContFileName,
+                         covariateRefFileName, analysisRefFileName, timeRefFileName)) {
+
+      if (file.exists(outputFile)) {
+        ParallelLogger::logInfo("Not in incremental mode - Removing file", outputFile, " and replacing")
+        unlink(outputFile)
+      }
+    }
+  }
+
   if (incremental &&
     (length(instantiatedCohorts) - nrow(subset)) > 0) {
     ParallelLogger::logInfo(sprintf(

--- a/R/CohortRelationship.R
+++ b/R/CohortRelationship.R
@@ -204,7 +204,7 @@ executeCohortRelationshipDiagnostics <- function(connection,
                                                  minCellCount,
                                                  recordKeepingFile,
                                                  incremental,
-                                                 batchSize = 500) {
+                                                 batchSize = getOption("CohortDiagnostics-Relationship-batch-size", default = 500)) {
   ParallelLogger::logInfo("Computing Cohort Relationship")
   startCohortRelationship <- Sys.time()
 

--- a/R/CohortRelationship.R
+++ b/R/CohortRelationship.R
@@ -311,6 +311,12 @@ executeCohortRelationshipDiagnostics <- function(connection,
       )
     }
 
+    outputFile <- file.path(exportFolder, "cohort_relationships.csv")
+    if (!incremental & file.exists(outputFile)) {
+      ParallelLogger::logInfo("Time series file exists, removing before batch operations")
+      unlink(outputFile)
+    }
+
     for (start in seq(1, nrow(subset), by = batchSize)) {
       end <- min(start + batchSize - 1, nrow(subset))
 
@@ -353,8 +359,8 @@ executeCohortRelationshipDiagnostics <- function(connection,
 
       writeToCsv(
         data = data,
-        fileName = file.path(exportFolder, "cohort_relationships.csv"),
-        incremental = incremental
+        fileName = outputFile,
+        incremental = TRUE
       )
 
       recordTasksDone(

--- a/R/ExportCharacterization.R
+++ b/R/ExportCharacterization.R
@@ -70,7 +70,7 @@ exportCharacterization <- function(characteristics,
       writeToCsv(
         data = covariateRef,
         fileName = covariateRefFileName,
-        incremental = incremental,
+        incremental = TRUE,
         covariateId = covariateRef$covariateId
       )
 
@@ -82,7 +82,7 @@ exportCharacterization <- function(characteristics,
       writeToCsv(
         data = analysisRef,
         fileName = analysisRefFileName,
-        incremental = incremental,
+        incremental = TRUE,
         analysisId = analysisRef$analysisId
       )
 
@@ -94,14 +94,14 @@ exportCharacterization <- function(characteristics,
       writeToCsv(
         data = timeRef,
         fileName = timeRefFileName,
-        incremental = incremental,
+        incremental = TRUE,
         analysisId = timeRef$timeId
       )
 
       writeToCsv(
         data = characteristics$filteredCovariates,
         fileName = covariateValueFileName,
-        incremental = incremental
+        incremental = TRUE
       )
     }
   }
@@ -120,7 +120,7 @@ exportCharacterization <- function(characteristics,
       writeToCsv(
         data = characteristics$filteredCovariatesContinous,
         fileName = covariateValueContFileName,
-        incremental = incremental
+        incremental = TRUE
       )
     }
   }

--- a/R/Private.R
+++ b/R/Private.R
@@ -317,8 +317,7 @@ timeExecution <- function(exportFolder,
                           parent = NULL,
                           start = NA,
                           execTime = NA,
-                          expr = NULL,
-                          env = parent.frame()) {
+                          expr = NULL) {
   executionTimePath <- file.path(exportFolder, "executionTimes.csv")
   if (is.na(start)) {
     start <- Sys.time()

--- a/R/TimeSeries.R
+++ b/R/TimeSeries.R
@@ -546,6 +546,11 @@ executeTimeSeriesDiagnostics <- function(connection,
         ))
       }
 
+      outputFile <- file.path(exportFolder, "time_series.csv")
+      if (!incremental & file.exists(outputFile)) {
+        ParallelLogger::logInfo("Time series file exists, removing before batch operations")
+        unlink(outputFile)
+      }
 
       for (start in seq(1, nrow(subset), by = batchSize)) {
         end <- min(start + batchSize - 1, nrow(subset))
@@ -591,8 +596,8 @@ executeTimeSeriesDiagnostics <- function(connection,
         )
         writeToCsv(
           data = data,
-          fileName = file.path(exportFolder, "time_series.csv"),
-          incremental = incremental,
+          fileName = outputFile,
+          incremental = TRUE,
           cohortId = subset[start:end,]$cohortId %>% unique()
         )
         recordTasksDone(

--- a/R/TimeSeries.R
+++ b/R/TimeSeries.R
@@ -519,7 +519,7 @@ executeTimeSeriesDiagnostics <- function(connection,
                                          incremental,
                                          recordKeepingFile,
                                          observationPeriodDateRange,
-                                         batchSize = 20) {
+                                         batchSize = getOption("CohortDiagnostics-TimeSeries-batch-size", default = 20)) {
 
   if (all(!runCohortTimeSeries, !runDataSourceTimeSeries)) {
     warning(


### PR DESCRIPTION
See #988 

@mdlavallee92 I think this may impact your PR but you also might see if I missed something with the fix proposed here.

Essentially this problem occurs when the batched operations are run when not using incremental mode. 
The fix in this PR is to delete the files before execution where incremental is false.