### PR TITLE
Increase concept.concept_code size in rdms - fixes #1036

### DIFF
--- a/inst/settings/resultsDataModelSpecification.csv
+++ b/inst/settings/resultsDataModelSpecification.csv
@@ -101,7 +101,7 @@ concept,domain_id,varchar(20),Yes,No,No,Yes,No,Yes,No
 concept,vocabulary_id,varchar(50),Yes,No,No,Yes,No,Yes,No
 concept,concept_class_id,varchar(20),Yes,No,No,Yes,No,Yes,No
 concept,standard_concept,varchar(1),No,No,No,Yes,No,Yes,No
-concept,concept_code,varchar(50),Yes,No,No,Yes,No,Yes,No
+concept,concept_code,varchar(255),Yes,No,No,Yes,No,Yes,No
 concept,valid_start_date,Date,Yes,No,No,Yes,No,Yes,No
 concept,valid_end_date,Date,Yes,No,No,Yes,No,Yes,No
 concept,invalid_reason,varchar,No,No,No,Yes,No,Yes,No


### PR DESCRIPTION
Updates `inst/settings/resultsDataModelSpecification.csv` to increase the size of `concept.concept_code` per #1036.