### PR TITLE
Fix subset conceptset analysis

### DIFF
--- a/R/ConceptSets.R
+++ b/R/ConceptSets.R
@@ -833,6 +833,18 @@ runConceptSetDiagnostics <- function(connection,
         }
       }
 
+      if (nrow(data) == 0 && ncol(data) == 0) {
+        data <- dplyr::tibble(
+          conceptId = numeric(),
+          conceptCount = numeric(),
+          subjectCount = numeric(),
+          cohortId = numeric(),
+          databaseId = character(),
+          domainField = character(),
+          domainTable = character()
+        )
+      }
+
       data <- makeDataExportable(
         x = data,
         tableName = "index_event_breakdown",

--- a/R/ConceptSets.R
+++ b/R/ConceptSets.R
@@ -157,9 +157,9 @@ combineConceptSetsFromCohorts <- function(cohorts) {
     }
 
     sqlCs <-
-      extractConceptSetsSqlFromCohortSql(cohortSql = cohort$sql)
+      extractConceptSetsSqlFromCohortSql(cohortSql = cohortSql)
     jsonCs <-
-      extractConceptSetsJsonFromCohortJson(cohortJson = cohort$json)
+      extractConceptSetsJsonFromCohortJson(cohortJson = cohortJson)
 
     if (nrow(sqlCs) == 0 || nrow(jsonCs) == 0) {
       ParallelLogger::logInfo(

--- a/tests/testthat/test-7-DatabaseMigrations.R
+++ b/tests/testthat/test-7-DatabaseMigrations.R
@@ -24,6 +24,7 @@ if (dbms == "postgresql") {
 
 test_that("Database Migrations execute without error", {
   skip_if_not(dbms %in% c("sqlite", "postgresql"))
+  skip_if(skipCdmTests, "cdm settings not configured")
 
   connection <- DatabaseConnector::connect(connectionDetails)
   on.exit(DatabaseConnector::disconnect(connection))


### PR DESCRIPTION
This fixes concept set analysis for subset cohorts. Concept sets are defined in parent cohorts, so that first we need to look for parent cohort. That was done, but then parent's cohort sql/json wasn't used - this is fixed.

I'm targeting main branch since the change is trivial and useful for what we're doing now. Please let me know if develop branch is preferred.
